### PR TITLE
Extended already existing logic for when to match request …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'cd.go.contrib'
-version = '0.7.0'
+version = '0.7.1'
 description = 'GoCD OpenStack Elastic Agents'
 
 // these values that go into plugin.xml

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/AgentInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/AgentInstances.java
@@ -72,7 +72,7 @@ public interface AgentInstances<T> {
 
     boolean isInstanceAlive(PluginSettings settings, String id) throws Exception;
 
-    boolean matchInstance(String id, Map<String, String> properties, PluginSettings pluginSettings, OpenstackClientWrapper client);
+    boolean matchInstance(String id, Map<String, String> properties, String environment, PluginSettings pluginSettings, OpenstackClientWrapper client);
 
     /**
      * This message is sent from the {@link cd.go.contrib.elasticagents.openstack.executors.ServerPingRequestExecutor}

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
@@ -23,10 +23,11 @@ import org.apache.commons.lang.time.DateUtils;
 import org.joda.time.Period;
 import org.openstack4j.api.OSClient;
 import org.openstack4j.model.compute.Server;
+
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static cd.go.contrib.elasticagents.openstack.OpenStackPlugin.LOG;
+import static org.apache.commons.lang.StringUtils.stripToEmpty;
 
 public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
 
@@ -106,10 +107,15 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
         return os_client(settings).compute().servers().get(id) == null ? false : true;
     }
 
-    public boolean matchInstance(String id, Map<String, String> properties, PluginSettings pluginSettings, OpenstackClientWrapper client){
+    public boolean matchInstance(String id, Map<String, String> properties, String environment, PluginSettings pluginSettings, OpenstackClientWrapper client){
         OpenStackInstance instance = this.find(id);
         if(instance == null)
             return false;
+
+        if (!stripToEmpty(environment).equalsIgnoreCase(stripToEmpty(instance.environment()))) {
+            return false;
+        }
+
         String proposedImageIdOrName = properties.get(Constants.OPENSTACK_IMAGE_ID_ARGS);
         String proposedFlavorIdOrName = properties.get(Constants.OPENSTACK_FLAVOR_ID_ARGS);
         if(StringUtils.isBlank(proposedImageIdOrName)) {

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutor.java
@@ -59,7 +59,7 @@ public class CreateAgentRequestExecutor implements RequestExecutor {
 
         for (Agent agent : agents.agents()) {
             LOG.debug("Check if agent: " + agent + " match job profile.");
-            if (agentInstances.matchInstance(agent.elasticAgentId(), request.properties(), pluginRequest.getPluginSettings(), clientWrapper)) {
+            if (agentInstances.matchInstance(agent.elasticAgentId(), request.properties(), request.environment(), pluginRequest.getPluginSettings(), clientWrapper)) {
                 matchingAgentCount++;
                 LOG.debug("Check agent: " + agent.elasticAgentId() + " is " + agent.agentState());
                 if (matchingAgentCount >= maxInstanceLimit) {

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/ShouldAssignWorkRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/ShouldAssignWorkRequestExecutor.java
@@ -38,20 +38,21 @@ public class ShouldAssignWorkRequestExecutor implements RequestExecutor {
 
     @Override
     public GoPluginApiResponse execute() throws Exception {
-        OpenStackInstance instance =  (OpenStackInstance) agentInstances.find(request.agent().elasticAgentId());
+        OpenStackInstance instance = (OpenStackInstance) agentInstances.find(request.agent().elasticAgentId());
 
-        if (instance == null){
+        LOG.info("Trying to match Elastic Agent with work request : " + request);
+
+        if (instance == null) {
+            LOG.info("Work can NOT be assigned to missing Elastic Agent: " + request.agent().elasticAgentId());
             return DefaultGoPluginApiResponse.success("false");
         }
 
-        boolean environmentMatches = stripToEmpty(request.environment()).equalsIgnoreCase(stripToEmpty(instance.environment()));
-
-        LOG.debug("Elastic Agent should assign work request : " + request);
-
         OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(pluginRequest.getPluginSettings());
-        if ((agentInstances.matchInstance(request.agent().elasticAgentId(),request.properties(), pluginRequest.getPluginSettings(), clientWrapper)) && environmentMatches){
+        if ((agentInstances.matchInstance(request.agent().elasticAgentId(), request.properties(), request.environment(), pluginRequest.getPluginSettings(), clientWrapper)) ) {
+            LOG.info("Work can be assigned to Elastic Agent : " + request.agent().elasticAgentId());
             return DefaultGoPluginApiResponse.success("true");
-        }else{
+        } else {
+            LOG.info("Work can NOT be assigned to Elastic Agent : " + request.agent().elasticAgentId());
             return DefaultGoPluginApiResponse.success("false");
         }
     }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/requests/CreateAgentRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/requests/CreateAgentRequest.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public class CreateAgentRequest {
     public static final Gson GSON = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
     private String autoRegisterKey;
-    private Map<String,String> properties;
+    private Map<String, String> properties;
     private String environment;
 
 
@@ -41,7 +41,7 @@ public class CreateAgentRequest {
 
     }
 
-    public CreateAgentRequest(String autoRegisterKey, Map<String,String> properties, String environment) {
+    public CreateAgentRequest(String autoRegisterKey, Map<String, String> properties, String environment) {
         this.autoRegisterKey = autoRegisterKey;
         this.properties = properties;
         this.environment = environment;
@@ -51,7 +51,7 @@ public class CreateAgentRequest {
         return autoRegisterKey;
     }
 
-    public Map<String,String> properties() {
+    public Map<String, String> properties() {
         return properties;
     }
 

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/OpenStackInstancesTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/OpenStackInstancesTest.java
@@ -8,7 +8,7 @@ import java.util.Date;
 import java.util.HashMap;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,14 +54,14 @@ public class OpenStackInstancesTest {
     public void matchInstanceShouldReturnTrueWhenRequestHasNoPropertiesButSettingsMatchAfterResolvingNames() throws Exception {
         pluginSettings.setOpenstackFlavor("m1.small");
         pluginSettings.setOpenstackImage("ubuntu-14");
-        assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), pluginSettings, client), is(true));
+        assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), null, pluginSettings, client), is(true));
     }
 
     @Test
     public void matchInstanceShouldReturnTrueWhenRequestHasNoPropertiesButSettingsMatchById() throws Exception {
         pluginSettings.setOpenstackFlavor(instance.getFlavorId());
         pluginSettings.setOpenstackImage(instance.getImageId());
-        assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), pluginSettings, client), is(true));
+        assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), null, pluginSettings, client), is(true));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class OpenStackInstancesTest {
         HashMap<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
-        assertThat(instances.matchInstance(instanceId, properties, pluginSettings, client), is(true));
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(true));
     }
 
     @Test
@@ -77,12 +77,12 @@ public class OpenStackInstancesTest {
         HashMap<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "ubuntu-14");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "m1.small");
-        assertThat(instances.matchInstance(instanceId, properties, pluginSettings, client), is(true));
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(true));
     }
 
     @Test
     public void matchInstanceShouldReturnFalseWhenRequestHasNoPropertiesAndSettingsDontMatch() throws Exception {
-        assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), pluginSettings, client), is(false));
+        assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), null, pluginSettings, client), is(false));
     }
 
     @Test
@@ -91,7 +91,7 @@ public class OpenStackInstancesTest {
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "5db97077-b9f0-46f9-a992-15708ad3b83d");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
         when(client.getImageId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
-        assertThat(instances.matchInstance(instanceId, properties, pluginSettings, client), is(false));
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(false));
     }
 
     @Test
@@ -100,15 +100,58 @@ public class OpenStackInstancesTest {
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "5db97077-b9f0-46f9-a992-15708ad3b83d");
         when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
-        assertThat(instances.matchInstance(instanceId, properties, pluginSettings, client), is(false));
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(false));
     }
+
+    @Test
+    public void matchInstanceShouldReturnFalseWhenEnvironmentIsNotEqual() throws Exception {
+        instanceId = "b45b5658-b093-4a58-bf22-17d898171c95";
+        instance = new OpenStackInstance(instanceId, new Date(), "testing",
+                "7637f039-027d-471f-8d6c-4177635f84f8", "c1980bb5-ed59-4573-83c9-8391b53b3a55");
+        instances = new OpenStackInstances();
+        instances.register(instance);
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
+        properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
+        when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(false));
+    }
+
 
     @Test
     public void matchInstanceShouldReturnTrueWhenFlavorIdAndImageIsEqual() throws Exception {
         HashMap<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
-        assertThat(instances.matchInstance(instanceId, properties, pluginSettings, client), is(true));
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(true));
+    }
+
+    @Test
+    public void matchInstanceShouldReturnTrueWhenEnvironmentIsEqual() throws Exception {
+        instanceId = "b45b5658-b093-4a58-bf22-17d898171c95";
+        instance = new OpenStackInstance(instanceId, new Date(), "testing",
+                "7637f039-027d-471f-8d6c-4177635f84f8", "c1980bb5-ed59-4573-83c9-8391b53b3a55");
+        instances = new OpenStackInstances();
+        instances.register(instance);
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
+        properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
+        when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
+        assertThat(instances.matchInstance(instanceId, properties, "testing", pluginSettings, client), is(true));
+    }
+
+    @Test
+    public void matchInstanceShouldReturnTrueWhenEnvironmentIsNull() throws Exception {
+        instanceId = "b45b5658-b093-4a58-bf22-17d898171c95";
+        instance = new OpenStackInstance(instanceId, new Date(), null,
+                "7637f039-027d-471f-8d6c-4177635f84f8", "c1980bb5-ed59-4573-83c9-8391b53b3a55");
+        instances = new OpenStackInstances();
+        instances.register(instance);
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
+        properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
+        when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(true));
     }
 
 }

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutorTest.java
@@ -46,7 +46,7 @@ public class CreateAgentRequestExecutorTest {
         // Arrange
         when(pluginRequest.listAgents()).thenReturn(agents);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), any(PluginSettings.class), any(OpenstackClientWrapper
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
                 .class))).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
@@ -63,8 +63,28 @@ public class CreateAgentRequestExecutorTest {
         agents.add(new Agent("id1", Agent.AgentState.Building, Agent.BuildState.Building, Agent.ConfigState.Enabled));
         when(pluginRequest.listAgents()).thenReturn(agents);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), any(PluginSettings.class), any(OpenstackClientWrapper
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
                 .class))).thenReturn(true);
+        CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
+
+        // Act
+        executor.execute();
+
+        // Assert
+        verify(agentInstances, times(1)).create(any(CreateAgentRequest.class), any(PluginSettings.class));
+    }
+
+    @Test
+    public void executeShouldCreateAgentWhenOnlyAgentsWithoutEnvironmentExist() throws Exception {
+        // Arrange
+        agents.add(new Agent("id1", Agent.AgentState.Building, Agent.BuildState.Building, Agent.ConfigState.Enabled));
+        when(pluginRequest.listAgents()).thenReturn(agents);
+        when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
+                .class))).thenReturn(true);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, "3");
+        createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
@@ -80,8 +100,11 @@ public class CreateAgentRequestExecutorTest {
         agents.add(new Agent("id1", Agent.AgentState.Idle, Agent.BuildState.Idle, Agent.ConfigState.Enabled));
         when(pluginRequest.listAgents()).thenReturn(agents);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), any(PluginSettings.class), any(OpenstackClientWrapper
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
                 .class))).thenReturn(true);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, "");
+        createAgentRequest = new CreateAgentRequest("abc-key", properties, "");
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
@@ -98,7 +121,9 @@ public class CreateAgentRequestExecutorTest {
         agents.add(new Agent("id2", Agent.AgentState.Building, Agent.BuildState.Building, Agent.ConfigState.Enabled));
         when(pluginRequest.listAgents()).thenReturn(agents);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), any(PluginSettings.class), any(OpenstackClientWrapper
+        Map<String, String> properties = new HashMap<>();
+        createAgentRequest = new CreateAgentRequest("abc-key", properties, "");
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
                 .class))).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
@@ -118,9 +143,9 @@ public class CreateAgentRequestExecutorTest {
         when(pluginRequest.listAgents()).thenReturn(agents);
         Map<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, "3");
-        createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
+        createAgentRequest = new CreateAgentRequest("abc-key", properties, "");
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), any(PluginSettings.class), any(OpenstackClientWrapper
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
                 .class))).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
@@ -139,7 +164,7 @@ public class CreateAgentRequestExecutorTest {
         properties.put(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, "");
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), any(PluginSettings.class), any(OpenstackClientWrapper
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
                 .class))).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
@@ -164,7 +189,7 @@ public class CreateAgentRequestExecutorTest {
         properties.put(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, "3");
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), any(PluginSettings.class), any(OpenstackClientWrapper
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
                 .class))).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
@@ -193,7 +218,7 @@ public class CreateAgentRequestExecutorTest {
         Map<String, String> properties = new HashMap<>();
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), any(PluginSettings.class), any(OpenstackClientWrapper
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
                 .class))).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 


### PR DESCRIPTION
… to create instances.

Will now match environment both when trying to assign work AND when deciding to create a new instance.
This was previously only done during the work assignment resulting in no new agents being created and the existing could not be used to assign work.
Added tests and logging.
Bump patch version since it was almost already working as intended.
Fixes #4 