### PR TITLE
Changes for issue #9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'cd.go.contrib'
-version = '0.8.1'
+version = '0.8.2'
 description = 'GoCD OpenStack Elastic Agents'
 
 // these values that go into plugin.xml

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/AgentInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/AgentInstances.java
@@ -34,10 +34,11 @@ public interface AgentInstances<T> {
      * So that instances created are auto-registered with the server, the agent instance should have an
      * <code>autoregister.properties</code>.
      *
-     * @param request   the request object
-     * @param settings  the plugin settings object
+     * @param request       the request object
+     * @param settings        the plugin settings object
+     * @param transactionId
      */
-    T create(CreateAgentRequest request, PluginSettings settings) throws Exception;
+    T create(CreateAgentRequest request, PluginSettings settings, String transactionId) throws Exception;
 
     /**
      * This message is sent to assist the plugin to refresh any metadata about the agent.
@@ -73,7 +74,7 @@ public interface AgentInstances<T> {
     boolean isInstanceAlive(PluginSettings settings, String id) throws Exception;
 
     boolean matchInstance(String id, Map<String, String> properties, String environment, PluginSettings pluginSettings, OpenstackClientWrapper client,
-                          String transactionId);
+                          String transactionId, boolean usePreviousImageId);
 
     /**
      * This message is sent from the {@link cd.go.contrib.elasticagents.openstack.executors.ServerPingRequestExecutor}

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/AgentInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/AgentInstances.java
@@ -30,7 +30,7 @@ public interface AgentInstances<T> {
     /**
      * This message is sent to request creation of an agent instance.
      * Implementations may, at their discretion choose to not spin up an agent instance.
-     *
+     * <p>
      * So that instances created are auto-registered with the server, the agent instance should have an
      * <code>autoregister.properties</code>.
      *
@@ -72,7 +72,8 @@ public interface AgentInstances<T> {
 
     boolean isInstanceAlive(PluginSettings settings, String id) throws Exception;
 
-    boolean matchInstance(String id, Map<String, String> properties, String environment, PluginSettings pluginSettings, OpenstackClientWrapper client);
+    boolean matchInstance(String id, Map<String, String> properties, String environment, PluginSettings pluginSettings, OpenstackClientWrapper client,
+                          String transactionId);
 
     /**
      * This message is sent from the {@link cd.go.contrib.elasticagents.openstack.executors.ServerPingRequestExecutor}

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstance.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstance.java
@@ -108,7 +108,7 @@ public class OpenStackInstance {
         String instance_name;
 
         HashMap<String, String> mdata = new HashMap<>();
-        
+
         Iterator entries = request.properties().entrySet().iterator();
         while(entries.hasNext()){
             Map.Entry entry = (Map.Entry) entries.next();
@@ -198,5 +198,17 @@ public class OpenStackInstance {
 
     public String getFlavorId() {
         return flavorId;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("OpenStackInstance{");
+        sb.append("id='").append(id).append('\'');
+        sb.append(", createdAt=").append(createdAt);
+        sb.append(", environment='").append(environment).append('\'');
+        sb.append(", imageId='").append(imageId).append('\'');
+        sb.append(", flavorId='").append(flavorId).append('\'');
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstance.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstance.java
@@ -103,7 +103,7 @@ public class OpenStackInstance {
         os_client.compute().servers().delete(id);
     }
 
-    public static OpenStackInstance create(CreateAgentRequest request, PluginSettings settings, OSClient osclient) throws InterruptedException, OS4JException, IOException {
+    public static OpenStackInstance create(CreateAgentRequest request, PluginSettings settings, OSClient osclient, String transactionId) throws InterruptedException, OS4JException, IOException {
 
         String instance_name;
 
@@ -152,7 +152,7 @@ public class OpenStackInstance {
         String networkId = StringUtils.isNotBlank(request.properties().get(Constants.OPENSTACK_NETWORK_ID_ARGS)) ? request.properties().get(Constants.OPENSTACK_NETWORK_ID_ARGS) : settings.getOpenstackNetwork();
         OpenstackClientWrapper client = new OpenstackClientWrapper(osclient);
         ServerCreateBuilder scb = Builders.server()
-                .image(client.getImageId(imageNameOrId))
+                .image(client.getImageId(imageNameOrId, transactionId))
                 .name(instance_name)
                 .flavor(client.getFlavorId(flavorNameOrId))
                 .networks(Arrays.asList(networkId))

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/PluginSettings.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/PluginSettings.java
@@ -75,6 +75,10 @@ public class PluginSettings {
     private String openstackImage;
 
     @Expose
+    @SerializedName("use_previous_openstack_image")
+    private Boolean usePreviousOpenstackImage;
+
+    @Expose
     @SerializedName("openstack_flavor")
     private String openstackFlavor;
 
@@ -195,6 +199,10 @@ public class PluginSettings {
         return openstackImage;
     }
 
+    public Boolean getUsePreviousOpenstackImage() {
+        return usePreviousOpenstackImage;
+    }
+
     public String getOpenstackFlavor() {
         return openstackFlavor;
     }
@@ -237,6 +245,10 @@ public class PluginSettings {
 
     public void setOpenstackImage(String openstackImage) {
         this.openstackImage = openstackImage;
+    }
+
+    public void setUsePreviousOpenstackImage(Boolean usePreviousOpenstackImage) {
+        this.usePreviousOpenstackImage = usePreviousOpenstackImage;
     }
 
     public void setOpenstackFlavor(String openstackFlavor) {

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutor.java
@@ -65,7 +65,7 @@ public class CreateAgentRequestExecutor implements RequestExecutor {
         for (Agent agent : agents.agents()) {
             LOG.debug(format("[{0}] [create-agent] Check if agent {1} match job profile", transactionId, agent));
             if (agentInstances.matchInstance(agent.elasticAgentId(), request.properties(), request.environment(), pluginRequest.getPluginSettings(),
-                    clientWrapper, transactionId)) {
+                    clientWrapper, transactionId, false)) {
                 matchingAgentCount++;
                 LOG.debug(format("[{0}] [create-agent] found matching agent {1} ", transactionId, agent.elasticAgentId()));
                 if (matchingAgentCount >= maxInstanceLimit) {
@@ -78,7 +78,7 @@ public class CreateAgentRequestExecutor implements RequestExecutor {
             }
         }
         LOG.info(format("[{0}] [create-agent] Will create new agent since no matching agents found", transactionId));
-        agentInstances.create(request, pluginRequest.getPluginSettings());
+        agentInstances.create(request, pluginRequest.getPluginSettings(), transactionId);
         return new DefaultGoPluginApiResponse(200);
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetPluginConfigurationExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetPluginConfigurationExecutor.java
@@ -39,11 +39,12 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
     public static final Field OPENSTACK_PASSWORD = new NonBlankField("openstack_password", "OpenStack Password", null, true, true, "7");
     public static final Field OPENSTACK_VM_PREFIX = new NonBlankField("openstack_vm_prefix", "OpenStack VM Prefix", null, true, false, "8");
     public static final Field OPENSTACK_IMAGE = new NonBlankField("openstack_image", "OpenStack Image", null, true, false, "9");
-    public static final Field OPENSTACK_FLAVOR = new NonBlankField("openstack_flavor", "OpenStack Flavor", null, true, false, "10");
-    public static final Field OPENSTACK_NETWORK = new NonBlankField("openstack_network", "OpenStack Network", null, true, false, "11");
-    public static final Field DEFAULT_MAX_INSTANCE_LIMIT = new PositiveNumberField("default_max_instance_limit", "Default Max Instance Limit", "12", true,
-            false, "10");
-    public static final Field OPENSTACK_USERDATA = new Field("openstack_userdata", "OpenStack Userdata", null, false, false, "13");
+    public static final Field USE_PREVIOUS_OPENSTACK_IMAGE = new NonBlankField("use_previous_openstack_image", "Allow Use of Previous Openstack Image", "false", true, false, "10");
+    public static final Field OPENSTACK_FLAVOR = new NonBlankField("openstack_flavor", "OpenStack Flavor", null, true, false, "11");
+    public static final Field OPENSTACK_NETWORK = new NonBlankField("openstack_network", "OpenStack Network", null, true, false, "12");
+    public static final Field DEFAULT_MAX_INSTANCE_LIMIT = new PositiveNumberField("default_max_instance_limit", "Default Max Instance Limit", "10", true,
+            false, "13");
+    public static final Field OPENSTACK_USERDATA = new Field("openstack_userdata", "OpenStack Userdata", null, false, false, "14");
 
     //public static final Field AGENT_RESOURCES = new Field("resources", "Agent Resources", null, false, false, "11");
     //public static final Field AGENT_ENVIRONMENTS = new Field("environments", "Environments", null, false, false, "12");
@@ -62,6 +63,7 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
         FIELDS.put(OPENSTACK_PASSWORD.key(), OPENSTACK_PASSWORD);
         FIELDS.put(OPENSTACK_VM_PREFIX.key(), OPENSTACK_VM_PREFIX);
         FIELDS.put(OPENSTACK_IMAGE.key(), OPENSTACK_IMAGE);
+        FIELDS.put(USE_PREVIOUS_OPENSTACK_IMAGE.key(), USE_PREVIOUS_OPENSTACK_IMAGE);
         FIELDS.put(OPENSTACK_FLAVOR.key(), OPENSTACK_FLAVOR);
         FIELDS.put(OPENSTACK_NETWORK.key(), OPENSTACK_NETWORK);
         FIELDS.put(OPENSTACK_USERDATA.key(), OPENSTACK_USERDATA);

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/ShouldAssignWorkRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/ShouldAssignWorkRequestExecutor.java
@@ -50,7 +50,7 @@ public class ShouldAssignWorkRequestExecutor implements RequestExecutor {
         }
 
         OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(pluginRequest.getPluginSettings());
-        if ((agentInstances.matchInstance(request.agent().elasticAgentId(), request.properties(), request.environment(), pluginRequest.getPluginSettings(), clientWrapper, transactionId, true)) ) {
+        if ((agentInstances.matchInstance(request.agent().elasticAgentId(), request.properties(), request.environment(), pluginRequest.getPluginSettings(), clientWrapper, transactionId, pluginRequest.getPluginSettings().getUsePreviousOpenstackImage())) ) {
             LOG.info(format("[{0}] [should-assign-work] Work can be assigned to Agent {1}", transactionId, request.agent().elasticAgentId()));
             return DefaultGoPluginApiResponse.success("true");
         } else {

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/ShouldAssignWorkRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/ShouldAssignWorkRequestExecutor.java
@@ -50,7 +50,7 @@ public class ShouldAssignWorkRequestExecutor implements RequestExecutor {
         }
 
         OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(pluginRequest.getPluginSettings());
-        if ((agentInstances.matchInstance(request.agent().elasticAgentId(), request.properties(), request.environment(), pluginRequest.getPluginSettings(), clientWrapper, transactionId)) ) {
+        if ((agentInstances.matchInstance(request.agent().elasticAgentId(), request.properties(), request.environment(), pluginRequest.getPluginSettings(), clientWrapper, transactionId, true)) ) {
             LOG.info(format("[{0}] [should-assign-work] Work can be assigned to Agent {1}", transactionId, request.agent().elasticAgentId()));
             return DefaultGoPluginApiResponse.success("true");
         } else {

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/requests/CreateAgentRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/requests/CreateAgentRequest.java
@@ -36,7 +36,6 @@ public class CreateAgentRequest {
     private Map<String, String> properties;
     private String environment;
 
-
     public CreateAgentRequest() {
 
     }
@@ -45,6 +44,10 @@ public class CreateAgentRequest {
         this.autoRegisterKey = autoRegisterKey;
         this.properties = properties;
         this.environment = environment;
+    }
+
+    public static CreateAgentRequest fromJSON(String json) {
+        return GSON.fromJson(json, CreateAgentRequest.class);
     }
 
     public String autoRegisterKey() {
@@ -59,11 +62,17 @@ public class CreateAgentRequest {
         return environment;
     }
 
-    public static CreateAgentRequest fromJSON(String json) {
-        return GSON.fromJson(json, CreateAgentRequest.class);
-    }
-
     public RequestExecutor executor(AgentInstances agentInstances, PluginRequest pluginRequest) throws Exception {
         return new CreateAgentRequestExecutor(this, agentInstances, pluginRequest, new OpenstackClientWrapper(pluginRequest.getPluginSettings()));
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("CreateAgentRequest{");
+        sb.append("autoRegisterKey='").append(autoRegisterKey).append('\'');
+        sb.append(", properties=").append(properties);
+        sb.append(", environment='").append(environment).append('\'');
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/requests/ShouldAssignWorkRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/requests/ShouldAssignWorkRequest.java
@@ -33,6 +33,9 @@ public class ShouldAssignWorkRequest {
     private Agent agent;
     private Map<String, String> properties;
 
+    public static ShouldAssignWorkRequest fromJSON(String json) {
+        return GSON.fromJson(json, ShouldAssignWorkRequest.class);
+    }
 
     public Agent agent() {
         return agent;
@@ -46,21 +49,26 @@ public class ShouldAssignWorkRequest {
         return properties;
     }
 
-    public static ShouldAssignWorkRequest fromJSON(String json) {
-        return GSON.fromJson(json, ShouldAssignWorkRequest.class);
-    }
-
     public RequestExecutor executor(AgentInstances agentInstances, PluginRequest pluginRequest) {
         return new ShouldAssignWorkRequestExecutor(this, agentInstances, pluginRequest);
     }
 
-    @Override
-    public String toString() {
+    public String toJson() {
         Gson gson = new GsonBuilder()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .setPrettyPrinting()
                 .create();
         return gson.toJson(this);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("ShouldAssignWorkRequest{");
+        sb.append("environment='").append(environment).append('\'');
+        sb.append(", agent=").append(agent);
+        sb.append(", properties=").append(properties);
+        sb.append('}');
+        return sb.toString();
     }
 }
 

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/utils/Util.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/utils/Util.java
@@ -20,6 +20,8 @@ import cd.go.contrib.elasticagents.openstack.executors.GetViewRequestExecutor;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CharStreams;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,6 +30,8 @@ import java.io.StringReader;
 import java.util.Properties;
 
 public class Util {
+
+    public static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
 
     public static String readResource(String resourceFile) {
         try (InputStreamReader reader = new InputStreamReader(GetViewRequestExecutor.class.getResourceAsStream(resourceFile), Charsets.UTF_8)) {

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -75,6 +75,13 @@
 </div>
 
 <div class="form_item_block">
+  <label>Allow Use of Previous Openstack Image</label>
+  <input type="radio" ng-model="use_previous_openstack_image" value="true"/> True
+  <input type="radio" ng-model="use_previous_openstack_image" value="false"/> False
+  <span class="form_error" ng-show="GOINPUTNAME[use_previous_openstack_image].$error.server">{{ GOINPUTNAME[use_previous_openstack_image].$error.server}}</span>
+</div>
+
+<div class="form_item_block">
   <label>Openstack Flavor<span class='asterix'>*</span></label>
   <input type="text" ng-model="openstack_flavor" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_flavor].$error.server">{{ GOINPUTNAME[openstack_flavor].$error.server}}</span>

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -15,73 +15,73 @@
   -->
 
 <div class="form_item_block">
-  <label>Go Server URL:<span class='asterix'>*</span></label>
+  <label>Go Server URL<span class='asterix'>*</span></label>
   <input type="text" ng-model="go_server_url" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[go_server_url].$error.server">{{ GOINPUTNAME[go_server_url].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Agent auto-register Timeout (in minutes)<span class='asterix'>*</span></label>
+  <label>Agent Time to live (in minutes)<span class='asterix'>*</span></label>
   <input type="text" ng-model="auto_register_timeout" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[auto_register_timeout].$error.server">{{ GOINPUTNAME[auto_register_timeout].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Openstack Endpoint:<span class='asterix'>*</span></label>
+  <label>Openstack Endpoint<span class='asterix'>*</span></label>
   <input type="text" ng-model="openstack_endpoint" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_endpoint].$error.server">{{ GOINPUTNAME[openstack_endpoint].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Openstack Keystone Version:<span class='asterix'>*</span></label>
+  <label>Openstack Keystone Version<span class='asterix'>*</span></label>
   <input type="text" ng-model="openstack_keystone_version" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_keystone_version].$error.server">{{ GOINPUTNAME[openstack_keystone_version].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Openstack Domain:<span class='asterix'>*</span></label>
+  <label>Openstack Domain<span class='asterix'>*</span></label>
   <input type="text" ng-model="openstack_domain" ng-required="false"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_domain].$error.server">{{ GOINPUTNAME[openstack_domain].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Openstack Tenant:<span class='asterix'>*</span></label>
+  <label>Openstack Tenant<span class='asterix'>*</span></label>
   <input type="text" ng-model="openstack_tenant" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_tenant].$error.server">{{ GOINPUTNAME[openstack_tenant].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Openstack User:<span class='asterix'>*</span></label>
+  <label>Openstack User<span class='asterix'>*</span></label>
   <input type="text" ng-model="openstack_user" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_user].$error.server">{{ GOINPUTNAME[openstack_user].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Openstack Password:<span class='asterix'>*</span></label>
+  <label>Openstack Password<span class='asterix'>*</span></label>
   <input type="password" ng-model="openstack_password" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_password].$error.server">{{ GOINPUTNAME[openstack_password].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Openstack VM Prefix:<span class='asterix'>*</span></label>
+  <label>Openstack VM Prefix<span class='asterix'>*</span></label>
   <input type="text" ng-model="openstack_vm_prefix" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_vm_prefix].$error.server">{{ GOINPUTNAME[openstack_vm_prefix].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Openstack Image:<span class='asterix'>*</span></label>
+  <label>Openstack Image<span class='asterix'>*</span></label>
   <input type="text" ng-model="openstack_image" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_image].$error.server">{{ GOINPUTNAME[openstack_image].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Openstack Flavor:<span class='asterix'>*</span></label>
+  <label>Openstack Flavor<span class='asterix'>*</span></label>
   <input type="text" ng-model="openstack_flavor" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_flavor].$error.server">{{ GOINPUTNAME[openstack_flavor].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Openstack Network:<span class='asterix'>*</span></label>
+  <label>Openstack Network<span class='asterix'>*</span></label>
   <input type="text" ng-model="openstack_network" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_network].$error.server">{{ GOINPUTNAME[openstack_network].$error.server}}</span>
 </div>

--- a/src/main/resources/profile.template.html
+++ b/src/main/resources/profile.template.html
@@ -15,48 +15,43 @@
   -->
 
 <div class="form_item_block">
-    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_image_id].$error.server}">Openstack Image ID
-        :</label>
+    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_image_id].$error.server}">Openstack Image Name/ID</label>
     <input ng-class="{'is-invalid-input': GOINPUTNAME[openstack_image_id].$error.server}" type="text" ng-model="openstack_image_id" ng-required="false" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"/>
     <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[openstack_image_id].$error.server}" ng-show="GOINPUTNAME[openstack_image_id].$error.server">{{GOINPUTNAME[openstack_image_id].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_flavor_id].$error.server}">Openstack Flavor ID
-        :</label>
+    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_flavor_id].$error.server}">Openstack Flavor Name/ID</label>
     <input ng-class="{'is-invalid-input': GOINPUTNAME[openstack_flavor_id].$error.server}" type="text" ng-model="openstack_flavor_id" ng-required="false" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"/>
     <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[openstack_flavor_id].$error.server}" ng-show="GOINPUTNAME[openstack_flavor_id].$error.server">{{GOINPUTNAME[openstack_flavor_id].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_network_id].$error.server}">Openstack Network ID
-        :</label>
+    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_network_id].$error.server}">Openstack Network ID</label>
     <input ng-class="{'is-invalid-input': GOINPUTNAME[openstack_network_id].$error.server}" type="text" ng-model="openstack_network_id" ng-required="false" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"/>
     <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[openstack_network_id].$error.server}" ng-show="GOINPUTNAME[openstack_network_id].$error.server">{{GOINPUTNAME[openstack_network_id].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_security_group].$error.server}">Openstack Security Group
-        :</label>
+    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_security_group].$error.server}">Openstack Security Group</label>
     <input ng-class="{'is-invalid-input': GOINPUTNAME[openstack_security_group].$error.server}" type="text" ng-model="openstack_security_group" ng-required="true" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"/>
     <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[openstack_security_group].$error.server}" ng-show="GOINPUTNAME[openstack_security_group].$error.server">{{GOINPUTNAME[openstack_security_group].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_keypair].$error.server}">Openstack Keypair
-        :</label>
+    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_keypair].$error.server}">Openstack Keypair</label>
     <input ng-class="{'is-invalid-input': GOINPUTNAME[openstack_keypair].$error.server}" type="text" ng-model="openstack_keypair" ng-required="true" placeholder="SSH Key Pair"/>
     <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[openstack_keypair].$error.server}" ng-show="GOINPUTNAME[openstack_keypair].$error.server">{{GOINPUTNAME[openstack_keypair].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_max_instance_limit].$error.server}">Max Instance Limit:</label>
+    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_max_instance_limit].$error.server}">Max Instance Limit</label>
     <input ng-class="{'is-invalid-input': GOINPUTNAME[openstack_max_instance_limit].$error.server}" type="text" ng-model="openstack_max_instance_limit" ng-required="false" placeholder="10"/>
     <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[openstack_max_instance_limit].$error.server}" ng-show="GOINPUTNAME[openstack_max_instance_limit].$error.server">{{GOINPUTNAME[openstack_max_instance_limit].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_userdata].$error.server}">Openstack Userdata:</label>
+    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_userdata].$error.server}">Openstack Userdata</label>
     <textarea ng-class="{'is-invalid-input': GOINPUTNAME[openstack_userdata].$error.server}" type="text"
               ng-model="openstack_userdata" ng-required="false" rows="15"
               placeholder="Direct Input Script"></textarea>

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/OpenStackInstancesTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/OpenStackInstancesTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.UUID;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -18,6 +19,7 @@ public class OpenStackInstancesTest {
     private PluginSettings pluginSettings;
     private OpenStackInstance instance;
     private OpenstackClientWrapper client;
+    private String transactionId = UUID.randomUUID().toString();
 
     @Before
     public void SetUp() {
@@ -54,14 +56,14 @@ public class OpenStackInstancesTest {
     public void matchInstanceShouldReturnTrueWhenRequestHasNoPropertiesButSettingsMatchAfterResolvingNames() throws Exception {
         pluginSettings.setOpenstackFlavor("m1.small");
         pluginSettings.setOpenstackImage("ubuntu-14");
-        assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), null, pluginSettings, client), is(true));
+        assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), null, pluginSettings, client, transactionId), is(true));
     }
 
     @Test
     public void matchInstanceShouldReturnTrueWhenRequestHasNoPropertiesButSettingsMatchById() throws Exception {
         pluginSettings.setOpenstackFlavor(instance.getFlavorId());
         pluginSettings.setOpenstackImage(instance.getImageId());
-        assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), null, pluginSettings, client), is(true));
+        assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), null, pluginSettings, client, transactionId), is(true));
     }
 
     @Test
@@ -69,7 +71,7 @@ public class OpenStackInstancesTest {
         HashMap<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
-        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(true));
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client, transactionId), is(true));
     }
 
     @Test
@@ -77,12 +79,12 @@ public class OpenStackInstancesTest {
         HashMap<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "ubuntu-14");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "m1.small");
-        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(true));
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client, transactionId), is(true));
     }
 
     @Test
     public void matchInstanceShouldReturnFalseWhenRequestHasNoPropertiesAndSettingsDontMatch() throws Exception {
-        assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), null, pluginSettings, client), is(false));
+        assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), null, pluginSettings, client, transactionId), is(false));
     }
 
     @Test
@@ -91,7 +93,7 @@ public class OpenStackInstancesTest {
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "5db97077-b9f0-46f9-a992-15708ad3b83d");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
         when(client.getImageId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
-        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(false));
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client, transactionId), is(false));
     }
 
     @Test
@@ -100,7 +102,7 @@ public class OpenStackInstancesTest {
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "5db97077-b9f0-46f9-a992-15708ad3b83d");
         when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
-        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(false));
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client, transactionId), is(false));
     }
 
     @Test
@@ -114,7 +116,7 @@ public class OpenStackInstancesTest {
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
         when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
-        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(false));
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client, transactionId), is(false));
     }
 
 
@@ -123,7 +125,7 @@ public class OpenStackInstancesTest {
         HashMap<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
-        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(true));
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client, transactionId), is(true));
     }
 
     @Test
@@ -137,7 +139,7 @@ public class OpenStackInstancesTest {
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
         when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
-        assertThat(instances.matchInstance(instanceId, properties, "testing", pluginSettings, client), is(true));
+        assertThat(instances.matchInstance(instanceId, properties, "testing", pluginSettings, client, transactionId), is(true));
     }
 
     @Test
@@ -151,7 +153,7 @@ public class OpenStackInstancesTest {
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
         when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
-        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client), is(true));
+        assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client, transactionId), is(true));
     }
 
 }

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutorTest.java
@@ -9,6 +9,7 @@ import org.mockito.ArgumentMatchers;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -47,14 +48,14 @@ public class CreateAgentRequestExecutorTest {
         when(pluginRequest.listAgents()).thenReturn(agents);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
         when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
-                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
+                any(OpenstackClientWrapper.class), anyString(), anyBoolean())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
         executor.execute();
 
         // Assert
-        verify(agentInstances, times(1)).create(any(CreateAgentRequest.class), any(PluginSettings.class));
+        verify(agentInstances, times(1)).create(any(CreateAgentRequest.class), any(PluginSettings.class), anyString());
     }
 
     @Test
@@ -64,14 +65,14 @@ public class CreateAgentRequestExecutorTest {
         when(pluginRequest.listAgents()).thenReturn(agents);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
         when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
-                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
+                any(OpenstackClientWrapper.class), anyString(), anyBoolean())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
         executor.execute();
 
         // Assert
-        verify(agentInstances, times(1)).create(any(CreateAgentRequest.class), any(PluginSettings.class));
+        verify(agentInstances, times(1)).create(any(CreateAgentRequest.class), any(PluginSettings.class), anyString());
     }
 
     @Test
@@ -81,7 +82,7 @@ public class CreateAgentRequestExecutorTest {
         when(pluginRequest.listAgents()).thenReturn(agents);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
         when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
-                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
+                any(OpenstackClientWrapper.class), anyString(), anyBoolean())).thenReturn(true);
         Map<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, "3");
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
@@ -91,7 +92,7 @@ public class CreateAgentRequestExecutorTest {
         executor.execute();
 
         // Assert
-        verify(agentInstances, times(1)).create(any(CreateAgentRequest.class), any(PluginSettings.class));
+        verify(agentInstances, times(1)).create(any(CreateAgentRequest.class), any(PluginSettings.class), anyString());
     }
 
     @Test
@@ -101,7 +102,7 @@ public class CreateAgentRequestExecutorTest {
         when(pluginRequest.listAgents()).thenReturn(agents);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
         when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
-                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
+                any(OpenstackClientWrapper.class), anyString(), anyBoolean())).thenReturn(true);
         Map<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, "");
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "");
@@ -111,7 +112,7 @@ public class CreateAgentRequestExecutorTest {
         executor.execute();
 
         // Assert
-        verify(agentInstances, times(0)).create(any(CreateAgentRequest.class), any(PluginSettings.class));
+        verify(agentInstances, times(0)).create(any(CreateAgentRequest.class), any(PluginSettings.class), anyString());
     }
 
     @Test
@@ -124,14 +125,14 @@ public class CreateAgentRequestExecutorTest {
         Map<String, String> properties = new HashMap<>();
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "");
         when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
-                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
+                any(OpenstackClientWrapper.class), anyString(), anyBoolean())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
         executor.execute();
 
         // Assert
-        verify(agentInstances, times(0)).create(any(CreateAgentRequest.class), any(PluginSettings.class));
+        verify(agentInstances, times(0)).create(any(CreateAgentRequest.class), any(PluginSettings.class), anyString());
     }
 
     @Test
@@ -146,14 +147,14 @@ public class CreateAgentRequestExecutorTest {
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "");
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
         when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
-                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
+                any(OpenstackClientWrapper.class), anyString(), anyBoolean())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
         executor.execute();
 
         // Assert
-        verify(agentInstances, times(0)).create(any(CreateAgentRequest.class), any(PluginSettings.class));
+        verify(agentInstances, times(0)).create(any(CreateAgentRequest.class), any(PluginSettings.class), anyString());
     }
 
     @Test
@@ -165,14 +166,14 @@ public class CreateAgentRequestExecutorTest {
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
         when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
-                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
+                any(OpenstackClientWrapper.class), anyString(), anyBoolean())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
         executor.execute();
 
         // Assert
-        verify(agentInstances, times(1)).create(any(CreateAgentRequest.class), any(PluginSettings.class));
+        verify(agentInstances, times(1)).create(any(CreateAgentRequest.class), any(PluginSettings.class), anyString());
     }
 
     @Test
@@ -190,14 +191,14 @@ public class CreateAgentRequestExecutorTest {
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
         when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
-                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
+                any(OpenstackClientWrapper.class), anyString(), anyBoolean())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
         executor.execute();
 
         // Assert
-        verify(agentInstances, times(0)).create(any(CreateAgentRequest.class), any(PluginSettings.class));
+        verify(agentInstances, times(0)).create(any(CreateAgentRequest.class), any(PluginSettings.class), anyString());
     }
 
     @Test
@@ -219,14 +220,14 @@ public class CreateAgentRequestExecutorTest {
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
         when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
-                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
+                any(OpenstackClientWrapper.class), anyString(), anyBoolean())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
         executor.execute();
 
         // Assert
-        verify(agentInstances, times(0)).create(any(CreateAgentRequest.class), any(PluginSettings.class));
+        verify(agentInstances, times(0)).create(any(CreateAgentRequest.class), any(PluginSettings.class), anyString());
     }
 
 }

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutorTest.java
@@ -46,8 +46,8 @@ public class CreateAgentRequestExecutorTest {
         // Arrange
         when(pluginRequest.listAgents()).thenReturn(agents);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
-                .class))).thenReturn(true);
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
+                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
@@ -63,8 +63,8 @@ public class CreateAgentRequestExecutorTest {
         agents.add(new Agent("id1", Agent.AgentState.Building, Agent.BuildState.Building, Agent.ConfigState.Enabled));
         when(pluginRequest.listAgents()).thenReturn(agents);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
-                .class))).thenReturn(true);
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
+                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
@@ -80,8 +80,8 @@ public class CreateAgentRequestExecutorTest {
         agents.add(new Agent("id1", Agent.AgentState.Building, Agent.BuildState.Building, Agent.ConfigState.Enabled));
         when(pluginRequest.listAgents()).thenReturn(agents);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
-                .class))).thenReturn(true);
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
+                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
         Map<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, "3");
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
@@ -100,8 +100,8 @@ public class CreateAgentRequestExecutorTest {
         agents.add(new Agent("id1", Agent.AgentState.Idle, Agent.BuildState.Idle, Agent.ConfigState.Enabled));
         when(pluginRequest.listAgents()).thenReturn(agents);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
-                .class))).thenReturn(true);
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
+                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
         Map<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, "");
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "");
@@ -123,8 +123,8 @@ public class CreateAgentRequestExecutorTest {
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
         Map<String, String> properties = new HashMap<>();
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "");
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
-                .class))).thenReturn(true);
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
+                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
@@ -145,8 +145,8 @@ public class CreateAgentRequestExecutorTest {
         properties.put(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, "3");
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "");
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
-                .class))).thenReturn(true);
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
+                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
@@ -164,8 +164,8 @@ public class CreateAgentRequestExecutorTest {
         properties.put(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, "");
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
-                .class))).thenReturn(true);
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
+                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
@@ -189,8 +189,8 @@ public class CreateAgentRequestExecutorTest {
         properties.put(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, "3");
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
-                .class))).thenReturn(true);
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
+                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act
@@ -218,8 +218,8 @@ public class CreateAgentRequestExecutorTest {
         Map<String, String> properties = new HashMap<>();
         createAgentRequest = new CreateAgentRequest("abc-key", properties, "testing");
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
-        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class), any(OpenstackClientWrapper
-                .class))).thenReturn(true);
+        when(agentInstances.matchInstance(anyString(), ArgumentMatchers.<String, String>anyMap(), anyString(), any(PluginSettings.class),
+                any(OpenstackClientWrapper.class), anyString())).thenReturn(true);
         CreateAgentRequestExecutor executor = new CreateAgentRequestExecutor(createAgentRequest, agentInstances, pluginRequest, openstackClientWrapper);
 
         // Act

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/utils/OpenstackClientWrapperTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/utils/OpenstackClientWrapperTest.java
@@ -8,6 +8,7 @@ import org.openstack4j.model.compute.Image;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -15,9 +16,10 @@ import static org.mockito.Mockito.*;
 
 public class OpenstackClientWrapperTest {
 
+    private String transactionId = UUID.randomUUID().toString();
 
     @Test
-    public void getImageId() {
+    public void shouldGetImageIdGivenImageName() {
 
         // Arrange
         String imageName = "ImageName";
@@ -46,9 +48,55 @@ public class OpenstackClientWrapperTest {
         final OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(client);
 
         // Act
-        final String imageId = clientWrapper.getImageId(imageName);
+        final String imageId = clientWrapper.getImageId(imageName, transactionId);
 
         // Assert
         assertEquals(expectedImageId, imageId);
+    }
+
+    @Test
+    public void shouldGetPreviousImageIdGivenImageName() {
+
+        // Arrange
+        String imageName = "ImageName";
+        String firstImageId = "firstImageId";
+        String secondImageId = "secondImageId";
+        String thirdImageId = "thirdImageId";
+        OSClient client = mock(OSClient.class);
+        final ComputeService compute = mock(ComputeService.class);
+        when(client.compute()).thenReturn(compute);
+        final ComputeImageService imageService = mock(ComputeImageService.class);
+        when(compute.images()).thenReturn(imageService);
+
+        when(imageService.get(anyString())).thenReturn(null);
+
+        List<Image> images = new ArrayList<>();
+        Image imageWithNullName = mock(Image.class);
+        when(imageWithNullName.getName()).thenReturn(null);
+        when(imageWithNullName.getId()).thenReturn("imageWithNullNameId");
+        images.add(imageWithNullName);
+
+        Image imageWithName = mock(Image.class);
+        when(imageWithName.getName()).thenReturn(imageName);
+        when(imageWithName.getId()).thenReturn(firstImageId);
+        images.add(imageWithName);
+
+        doReturn(images).when(imageService).list();
+
+        // Act
+        final OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(client);
+        clientWrapper.resetPreviousImages();
+
+        // Assert
+        assertEquals(firstImageId, clientWrapper.getImageId(imageName, transactionId));
+        assertEquals("", clientWrapper.getPreviousImageId(imageName, transactionId));
+
+        when(imageWithName.getId()).thenReturn(secondImageId);
+        assertEquals(secondImageId, clientWrapper.getImageId(imageName, transactionId));
+        assertEquals(firstImageId, clientWrapper.getPreviousImageId(imageName, transactionId));
+
+        when(imageWithName.getId()).thenReturn(thirdImageId);
+        assertEquals(thirdImageId, clientWrapper.getImageId(imageName, transactionId));
+        assertEquals(secondImageId, clientWrapper.getPreviousImageId(imageName, transactionId));
     }
 }


### PR DESCRIPTION
Changes for issue #9 
Allow the use of the previous image ID as a fallback when assigning work.

But the previous ID is not used when checking if any new agents should be created.