### PR TITLE
V3 extension API and pending agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.10.0
+
+ - Move to version 3.0 of the elastic agent endpoint, requires Go Server >= v18.2
+ - Added tracking of agent's instance before registration in server to prevent too many instances being created
+
 ### 0.9.0
 
 - Allow image fallback to previous ID when assigning work

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ To build the jar, run `./gradlew clean test assemble`
 
 ## TODO
 
-1. Openstack Keystone V3 API support
 2. Multi tenant/project support
 3. Multi authentication support ( eg. each pipeline can have their own openstack credential )
 4. More examples on how to create custom VM.

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ description = 'GoCD OpenStack Elastic Agents'
 project.ext.pluginDesc = [
         id         : 'cd.go.contrib.elastic-agent.openstack',
         version    : project.version,
-        goCdVersion: '18.3.0',
+        goCdVersion: '18.2.0',
         name       : 'Openstack Elastic Agent Plugin',
         description: 'Openstack Elastic Agent Plugin for GoCD',
         vendorName : 'ThoughtWorks Inc',

--- a/build.gradle
+++ b/build.gradle
@@ -18,14 +18,14 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'cd.go.contrib'
-version = '0.9.0'
+version = '0.10.0'
 description = 'GoCD OpenStack Elastic Agents'
 
 // these values that go into plugin.xml
 project.ext.pluginDesc = [
         id         : 'cd.go.contrib.elastic-agent.openstack',
         version    : project.version,
-        goCdVersion: '16.7.0',
+        goCdVersion: '18.3.0',
         name       : 'Openstack Elastic Agent Plugin',
         description: 'Openstack Elastic Agent Plugin for GoCD',
         vendorName : 'ThoughtWorks Inc',

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/AgentMatchResult.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/AgentMatchResult.java
@@ -1,0 +1,21 @@
+package cd.go.contrib.elasticagents.openstack;
+
+public class AgentMatchResult {
+
+    private boolean jobMatch;
+    private boolean profileMatch;
+
+    public AgentMatchResult(boolean jobMatch, boolean profileMatch) {
+
+        this.jobMatch = jobMatch;
+        this.profileMatch = profileMatch;
+    }
+
+    public boolean isJobMatch() {
+        return jobMatch;
+    }
+
+    public boolean isProfileMatch() {
+        return profileMatch;
+    }
+}

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/Constants.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/Constants.java
@@ -28,7 +28,7 @@ public interface Constants {
     String EXTENSION_TYPE = "elastic-agent";
 
     // The extension point API version that this plugin understands
-    String API_VERSION = "1.0";
+    String API_VERSION = "3.0";
 
     // the identifier of this plugin
     GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(API_VERSION));

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstance.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstance.java
@@ -147,8 +147,8 @@ public class OpenStackInstance {
         LOG.debug(request.properties().toString());
 
         final String encodedUserData = getEncodedUserData(request, settings);
-        String imageNameOrId = StringUtils.isNotBlank(request.properties().get(Constants.OPENSTACK_IMAGE_ID_ARGS)) ? request.properties().get(Constants.OPENSTACK_IMAGE_ID_ARGS) : settings.getOpenstackImage();
-        String flavorNameOrId = StringUtils.isNotBlank(request.properties().get(Constants.OPENSTACK_FLAVOR_ID_ARGS)) ? request.properties().get(Constants.OPENSTACK_FLAVOR_ID_ARGS) : settings.getOpenstackFlavor();
+        String imageNameOrId = getImageIdOrName(request, settings);
+        String flavorNameOrId = getFlavorIdOrName(request, settings);
         String networkId = StringUtils.isNotBlank(request.properties().get(Constants.OPENSTACK_NETWORK_ID_ARGS)) ? request.properties().get(Constants.OPENSTACK_NETWORK_ID_ARGS) : settings.getOpenstackNetwork();
         OpenstackClientWrapper client = new OpenstackClientWrapper(osclient);
         ServerCreateBuilder scb = Builders.server()
@@ -176,6 +176,14 @@ public class OpenStackInstance {
 
     }
 
+    public static String getFlavorIdOrName(CreateAgentRequest request, PluginSettings settings) {
+        return StringUtils.isNotBlank(request.properties().get(Constants.OPENSTACK_FLAVOR_ID_ARGS)) ? request.properties().get(Constants.OPENSTACK_FLAVOR_ID_ARGS) : settings.getOpenstackFlavor();
+    }
+
+    public static String getImageIdOrName(CreateAgentRequest request, PluginSettings settings) {
+        return StringUtils.isNotBlank(request.properties().get(Constants.OPENSTACK_IMAGE_ID_ARGS)) ? request.properties().get(Constants.OPENSTACK_IMAGE_ID_ARGS) : settings.getOpenstackImage();
+    }
+
     public static String getEncodedUserData(CreateAgentRequest request, PluginSettings settings) {
         String userData = getUserData(request, settings);
         if(userData == null)
@@ -192,11 +200,11 @@ public class OpenStackInstance {
         return settings.getOpenstackUserdata();
     }
 
-    public String getImageId() {
+    public String getImageIdOrName() {
         return imageId;
     }
 
-    public String getFlavorId() {
+    public String getFlavorIdOrName() {
         return flavorId;
     }
 

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
@@ -32,10 +32,7 @@ import static java.text.MessageFormat.format;
 import static org.apache.commons.lang.StringUtils.stripToEmpty;
 
 public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
-
-
     private final ConcurrentHashMap<String, OpenStackInstance> instances = new ConcurrentHashMap<>();
-    private final Map<String, OpenStackInstance> previousImageId = new ConcurrentHashMap<>();
     private boolean refreshed;
 
     @Override
@@ -73,7 +70,6 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
     @Override
     public void refreshAll(PluginRequest pluginRequest) throws Exception {
         if (!refreshed) {
-            String agentID;
             PluginSettings pluginSettings = pluginRequest.getPluginSettings();
             if(pluginSettings == null) {
                 LOG.warn("Openstack elastic agents plugin settings are empty");
@@ -142,23 +138,23 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
 
 
         LOG.debug(format("[{0}] [matchInstance] Trying to match image name/id: [{1}] with instance image: [{2}]", transactionId,
-                proposedImageIdOrName, instance.getImageId()));
-        if (!proposedImageIdOrName.equals(instance.getImageId())) {
+                proposedImageIdOrName, instance.getImageIdOrName()));
+        if (!proposedImageIdOrName.equals(instance.getImageIdOrName())) {
             LOG.debug(format("[{0}] [matchInstance] image name/id: [{1}] did NOT match with instance image: [{2}]", transactionId,
-                    proposedImageIdOrName, instance.getImageId()));
+                    proposedImageIdOrName, instance.getImageIdOrName()));
             String proposedImageId = client.getImageId(proposedImageIdOrName, transactionId);
             LOG.debug(format("[{0}] [matchInstance] Trying to match image id: [{1}] with instance image: [{2}]", transactionId,
-                    proposedImageId, instance.getImageId()));
-            if (!proposedImageId.equals(instance.getImageId())) {
+                    proposedImageId, instance.getImageIdOrName()));
+            if (!proposedImageId.equals(instance.getImageIdOrName())) {
                 LOG.debug(format("[{0}] [matchInstance] image id: [{1}] did NOT match with instance image: [{2}]", transactionId,
-                        proposedImageId, instance.getImageId()));
+                        proposedImageId, instance.getImageIdOrName()));
                 if (usePreviousImageId) {
                     proposedImageId = stripToEmpty(client.getPreviousImageId(proposedImageIdOrName, transactionId));
                     LOG.debug(format("[{0}] [matchInstance] Trying to match previous image id: [{1}] with instance image: [{2}]", transactionId,
-                            proposedImageId, instance.getImageId()));
-                    if (!proposedImageId.equals(instance.getImageId())) {
+                            proposedImageId, instance.getImageIdOrName()));
+                    if (!proposedImageId.equals(instance.getImageIdOrName())) {
                         LOG.debug(format("[{0}] [matchInstance] previous image id: [{1}] did NOT match with instance image: [{2}]", transactionId,
-                                proposedImageId, instance.getImageId()));
+                                proposedImageId, instance.getImageIdOrName()));
                         return false;
                     }
                 } else {
@@ -173,16 +169,16 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
             proposedFlavorIdOrName = pluginSettings.getOpenstackFlavor();
         }
         LOG.debug(format("[{0}] [matchInstance] Trying to match flavor name: [{1}] with instance flavor: [{2}]", transactionId,
-                proposedFlavorIdOrName, instance.getFlavorId()));
-        if (!proposedFlavorIdOrName.equals(instance.getFlavorId())) {
+                proposedFlavorIdOrName, instance.getFlavorIdOrName()));
+        if (!proposedFlavorIdOrName.equals(instance.getFlavorIdOrName())) {
             LOG.debug(format("[{0}] [matchInstance] flavor name: [{1}] did NOT match with instance flavor: [{2}]", transactionId,
-                    proposedFlavorIdOrName, instance.getFlavorId()));
+                    proposedFlavorIdOrName, instance.getFlavorIdOrName()));
             proposedFlavorIdOrName = client.getFlavorId(proposedFlavorIdOrName);
             LOG.debug(format("[{0}] [matchInstance] Trying to match flavor name: [{1}] with instance flavor: [{2}]", transactionId,
-                    proposedFlavorIdOrName, instance.getFlavorId()));
-            if (!proposedFlavorIdOrName.equals(instance.getFlavorId())) {
+                    proposedFlavorIdOrName, instance.getFlavorIdOrName()));
+            if (!proposedFlavorIdOrName.equals(instance.getFlavorIdOrName())) {
                 LOG.debug(format("[{0}] [matchInstance] flavor name: [{1}] did NOT match with instance flavor: [{2}]", transactionId,
-                        proposedFlavorIdOrName, instance.getFlavorId()));
+                        proposedFlavorIdOrName, instance.getFlavorIdOrName()));
                 return false;
             }
         }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
@@ -75,6 +75,10 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
         if (!refreshed) {
             String agentID;
             PluginSettings pluginSettings = pluginRequest.getPluginSettings();
+            if(pluginSettings == null) {
+                LOG.warn("Openstack elastic agents plugin settings are empty");
+                return;
+            }
             Agents agents = pluginRequest.listAgents();
             Map<String, String> op_instance_prefix = new HashMap<String, String>();
             op_instance_prefix.put("name", pluginSettings.getOpenstackVmPrefix());

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackPlugin.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackPlugin.java
@@ -51,6 +51,8 @@ public class OpenStackPlugin implements GoPlugin {
     public GoPluginApiResponse handle(GoPluginApiRequest request) throws UnhandledRequestTypeException {
         try {
             switch (Request.fromString(request.requestName())) {
+                case REQUEST_GET_CAPABILITIES:
+                    return new GetCapabilitiesExecutor().execute();
                 case REQUEST_SHOULD_ASSIGN_WORK:
                     refreshInstances();
                     return ShouldAssignWorkRequest.fromJSON(request.requestBody()).executor(agentInstances, pluginRequest).execute();

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/PendingAgent.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/PendingAgent.java
@@ -59,4 +59,11 @@ public class PendingAgent {
     public String elasticAgentId() {
         return pendingInstance.id();
     }
+
+    @Override
+    public String toString() {
+        return "PendingAgent{" +
+                "agentId='" + elasticAgentId() + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/PendingAgent.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/PendingAgent.java
@@ -1,0 +1,62 @@
+package cd.go.contrib.elasticagents.openstack;
+
+import cd.go.contrib.elasticagents.openstack.requests.CreateAgentRequest;
+
+import java.util.Map;
+
+import static cd.go.contrib.elasticagents.openstack.OpenStackPlugin.LOG;
+import static java.text.MessageFormat.format;
+import static org.apache.commons.lang.StringUtils.stripToEmpty;
+
+public class PendingAgent {
+    private final String pendingInstanceImageId;
+    private final String pendingInstanceFlavorId;
+    private OpenStackInstance pendingInstance;
+    private CreateAgentRequest createRequest;
+
+    public PendingAgent(OpenStackInstance pendingInstance, CreateAgentRequest request) {
+        this.pendingInstance = pendingInstance;
+        this.createRequest = request;
+        this.pendingInstanceImageId = pendingInstance.getImageIdOrName();
+        this.pendingInstanceFlavorId = pendingInstance.getFlavorIdOrName();
+    }
+
+    public AgentMatchResult match(String transactionId, String proposedImageIdOrName, String proposedFlavorIdOrName, String requestEnvironment, Map<String, Object> job) {
+        String id = this.elasticAgentId();
+        LOG.debug(format("[{0}] [matchPendingInstance] Instance: {1}", transactionId, id));
+
+        final String agentEnvironment = stripToEmpty(createRequest.environment());
+        requestEnvironment = stripToEmpty(requestEnvironment);
+        if (!requestEnvironment.equalsIgnoreCase(agentEnvironment)) {
+            LOG.debug(format("[{0}] [matchPendingInstance] Request environment [{1}] did NOT match agent's environment: [{2}]", transactionId, requestEnvironment,
+                    agentEnvironment));
+            return new AgentMatchResult(false, false);
+        }
+        LOG.debug(format("[{0}] [matchPendingInstance] Request environment [{1}] did match agent's environment: [{2}]", transactionId, requestEnvironment,
+                agentEnvironment));
+
+        LOG.debug(format("[{0}] [matchPendingInstance] Trying to match image name/id: [{1}] with instance image: [{2}]", transactionId,
+                proposedImageIdOrName, pendingInstanceImageId));
+        if (!proposedImageIdOrName.equals(pendingInstanceImageId)) {
+            LOG.debug(format("[{0}] [matchPendingInstance] image name/id: [{1}] did NOT match with instance image: [{2}]", transactionId,
+                    proposedImageIdOrName, pendingInstanceImageId));
+            return new AgentMatchResult(false, false);
+        }
+
+        LOG.debug(format("[{0}] [matchPendingInstance] Trying to match flavor name: [{1}] with instance flavor: [{2}]", transactionId,
+                proposedFlavorIdOrName, pendingInstanceFlavorId));
+        if (!proposedFlavorIdOrName.equals(pendingInstanceFlavorId)) {
+            LOG.debug(format("[{0}] [matchPendingInstance] flavor name: [{1}] did NOT match with instance flavor: [{2}]", transactionId,
+                    proposedFlavorIdOrName, pendingInstanceFlavorId));
+            return new AgentMatchResult(false, false);
+        }
+
+        boolean jobsMatch = createRequest.jobMatches(job);
+        LOG.info(format("[{0}] [matchPendingInstance] Found matching instance: {1} ByProfile=true, ByJob={2}", transactionId, id, jobsMatch));
+        return new AgentMatchResult(jobsMatch, true);
+    }
+
+    public String elasticAgentId() {
+        return pendingInstance.id();
+    }
+}

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/PendingAgentsService.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/PendingAgentsService.java
@@ -1,0 +1,56 @@
+package cd.go.contrib.elasticagents.openstack;
+
+import cd.go.contrib.elasticagents.openstack.requests.CreateAgentRequest;
+import com.thoughtworks.go.plugin.api.logging.Logger;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.text.MessageFormat.format;
+
+/**
+ * Keeps a record of agent instances which have been requested on openstack
+ * but not  yet registered with GoCD server.
+ */
+public class PendingAgentsService {
+    private static final Logger LOG = Logger.getLoggerFor(PendingAgentsService.class);
+
+    private AgentInstances agentInstances;
+    private final ConcurrentHashMap<String, PendingAgent> pendingAgents = new ConcurrentHashMap<>();
+
+    public PendingAgentsService(AgentInstances agentInstances) {
+        this.agentInstances = agentInstances;
+    }
+
+    public void addPending(OpenStackInstance pendingInstance, CreateAgentRequest request) {
+        pendingAgents.putIfAbsent(pendingInstance.id(), new PendingAgent(pendingInstance, request));
+    }
+
+    public PendingAgent[] getAgents() {
+        Collection<PendingAgent> values = pendingAgents.values();
+        return values.toArray(new PendingAgent[values.size()]);
+    }
+
+    public void refreshAll(PluginRequest pluginRequest) throws ServerRequestFailedException {
+        Agents registeredAgents = pluginRequest.listAgents();
+        for(Agent agent : registeredAgents.agents()) {
+            PendingAgent removed = pendingAgents.remove(agent.elasticAgentId());
+            if(removed != null)
+                LOG.info(format("[refresh-pending] Agent {0} is registered with GoCD server and is no longer pending", removed));
+        }
+        for (Iterator<Map.Entry<String, PendingAgent>> iter = pendingAgents.entrySet().iterator(); iter.hasNext(); ) {
+            Map.Entry<String, PendingAgent> entry = iter.next();
+            try {
+                if (!agentInstances.isInstanceAlive(pluginRequest.getPluginSettings(), entry.getKey())) {
+                    LOG.info(format("[refresh-pending] Pending agent {0} has disappeared from openstack", entry.getKey()));
+                    iter.remove();
+                }
+            } catch (Exception e) {
+                LOG.error("Failed to check instance state", e);
+            }
+        }
+        LOG.info(format("[refresh-pending] Total pending agent count = {0}", pendingAgents.size()));
+    }
+}

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/Request.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/Request.java
@@ -24,6 +24,7 @@ public enum Request {
     REQUEST_GET_PROFILE_METADATA(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".get-profile-metadata"),
     REQUEST_GET_PROFILE_VIEW(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".get-profile-view"),
     REQUEST_VALIDATE_PROFILE(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".validate-profile"),
+    REQUEST_GET_CAPABILITIES(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".get-capabilities"),
 
     // settings related requests that the server makes to the plugin
     PLUGIN_SETTINGS_GET_ICON(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".get-icon"),
@@ -51,7 +52,7 @@ public enum Request {
     }
 
     private static class Constants {
-        public static final String ELASTIC_AGENT_REQUEST_PREFIX = "go.cd.elastic-agent";
+        public static final String ELASTIC_AGENT_REQUEST_PREFIX = "cd.go.elastic-agent";
         public static final String GO_PLUGIN_SETTINGS_PREFIX = "go.plugin-settings";
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetCapabilitiesExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetCapabilitiesExecutor.java
@@ -1,0 +1,21 @@
+package cd.go.contrib.elasticagents.openstack.executors;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+
+public class GetCapabilitiesExecutor {
+    public static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+
+    private static final boolean SUPPORTS_STATUS_REPORT = false;
+    private static final boolean SUPPORTS_AGENT_STATUS_REPORT = false;
+
+    public GoPluginApiResponse execute() {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("supports_status_report", SUPPORTS_STATUS_REPORT);
+        jsonObject.addProperty("supports_agent_status_report", SUPPORTS_AGENT_STATUS_REPORT);
+        return DefaultGoPluginApiResponse.success(GSON.toJson(jsonObject));
+    }
+}

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/ServerPingRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/ServerPingRequestExecutor.java
@@ -37,8 +37,11 @@ public class ServerPingRequestExecutor implements RequestExecutor {
 
     @Override
     public GoPluginApiResponse execute() throws Exception {
-
         PluginSettings pluginSettings = pluginRequest.getPluginSettings();
+        if(pluginSettings == null) {
+            LOG.warn("Openstack elastic agents plugin settings are empty");
+            return DefaultGoPluginApiResponse.success("");
+        }
 
         Agents agents = pluginRequest.listAgents();
         Agents missingAgents = new Agents();

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/requests/CreateAgentRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/requests/CreateAgentRequest.java
@@ -34,6 +34,7 @@ public class CreateAgentRequest {
     public static final Gson GSON = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
     private String autoRegisterKey;
     private Map<String, String> properties;
+    private Map<String, String> jobIdentifier;
     private String environment;
 
     public CreateAgentRequest() {
@@ -70,6 +71,7 @@ public class CreateAgentRequest {
     public String toString() {
         final StringBuffer sb = new StringBuffer("CreateAgentRequest{");
         sb.append("autoRegisterKey='").append(autoRegisterKey).append('\'');
+        sb.append(", jobIdentifier=").append(jobIdentifier);
         sb.append(", properties=").append(properties);
         sb.append(", environment='").append(environment).append('\'');
         sb.append('}');

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/requests/CreateAgentRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/requests/CreateAgentRequest.java
@@ -17,6 +17,7 @@
 package cd.go.contrib.elasticagents.openstack.requests;
 
 import cd.go.contrib.elasticagents.openstack.AgentInstances;
+import cd.go.contrib.elasticagents.openstack.PendingAgentsService;
 import cd.go.contrib.elasticagents.openstack.PluginRequest;
 import cd.go.contrib.elasticagents.openstack.RequestExecutor;
 import cd.go.contrib.elasticagents.openstack.executors.CreateAgentRequestExecutor;
@@ -34,15 +35,16 @@ public class CreateAgentRequest {
     public static final Gson GSON = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
     private String autoRegisterKey;
     private Map<String, String> properties;
-    private Map<String, String> jobIdentifier;
+    private Map<String, Object> jobIdentifier;
     private String environment;
 
     public CreateAgentRequest() {
 
     }
 
-    public CreateAgentRequest(String autoRegisterKey, Map<String, String> properties, String environment) {
+    public CreateAgentRequest(String autoRegisterKey, Map<String, String> properties, Map<String, Object> jobIdentifier, String environment) {
         this.autoRegisterKey = autoRegisterKey;
+        this.jobIdentifier = jobIdentifier;
         this.properties = properties;
         this.environment = environment;
     }
@@ -63,8 +65,8 @@ public class CreateAgentRequest {
         return environment;
     }
 
-    public RequestExecutor executor(AgentInstances agentInstances, PluginRequest pluginRequest) throws Exception {
-        return new CreateAgentRequestExecutor(this, agentInstances, pluginRequest, new OpenstackClientWrapper(pluginRequest.getPluginSettings()));
+    public RequestExecutor executor(PendingAgentsService pendingAgents, AgentInstances agentInstances, PluginRequest pluginRequest) throws Exception {
+        return new CreateAgentRequestExecutor(this, agentInstances, pluginRequest, new OpenstackClientWrapper(pluginRequest.getPluginSettings()), pendingAgents);
     }
 
     @Override
@@ -76,5 +78,16 @@ public class CreateAgentRequest {
         sb.append(", environment='").append(environment).append('\'');
         sb.append('}');
         return sb.toString();
+    }
+
+    public Map<String, Object> job() {
+        return jobIdentifier;
+    }
+
+    public boolean jobMatches(Map<String, Object> otherJob) {
+        if(jobIdentifier.size() != otherJob.size())
+            return false;
+        return jobIdentifier.entrySet().containsAll(otherJob.entrySet());
+
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/requests/ShouldAssignWorkRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/requests/ShouldAssignWorkRequest.java
@@ -31,6 +31,7 @@ public class ShouldAssignWorkRequest {
     public static final Gson GSON = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
     private String environment;
     private Agent agent;
+    private Map<String, String> jobIdentifier;
     private Map<String, String> properties;
 
     public static ShouldAssignWorkRequest fromJSON(String json) {
@@ -65,6 +66,7 @@ public class ShouldAssignWorkRequest {
     public String toString() {
         final StringBuffer sb = new StringBuffer("ShouldAssignWorkRequest{");
         sb.append("environment='").append(environment).append('\'');
+        sb.append(", jobIdentifier=").append(jobIdentifier);
         sb.append(", agent=").append(agent);
         sb.append(", properties=").append(properties);
         sb.append('}');

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/utils/OpenstackClientWrapper.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/utils/OpenstackClientWrapper.java
@@ -38,20 +38,20 @@ public class OpenstackClientWrapper {
     }
 
     public String getImageId(String nameOrId, String transactionId) {
-        LOG.debug(format("[{0}] [getImageId] nameOrId [{1}]", transactionId, nameOrId));
+        LOG.debug(format("[{0}] [getImageIdOrName] nameOrId [{1}]", transactionId, nameOrId));
         Image image = client.compute().images().get(nameOrId);
         if (image == null) {
             for (Image tmpImage : client.compute().images().list()) {
                 String imageName = tmpImage.getName();
                 if (tmpImage.getName() != null && imageName.equals(nameOrId)) {
                     if (!previousImageIds.containsKey(imageName)) {
-                        LOG.debug(format("[{0}] [getImageId] initiate list of previous image is for name [{1}]", transactionId, imageName));
+                        LOG.debug(format("[{0}] [getImageIdOrName] initiate list of previous image is for name [{1}]", transactionId, imageName));
                         previousImageIds.put(tmpImage.getName(), new ArrayList<String>());
                     }
                     final List<String> usedImageIds = previousImageIds.get(imageName);
                     final String imageId = tmpImage.getId();
                     if (!usedImageIds.contains(imageId)) {
-                        LOG.debug(format("[{0}] [getImageId] for image name [{1}] add id [{2}]", transactionId, imageName, imageId));
+                        LOG.debug(format("[{0}] [getImageIdOrName] for image name [{1}] add id [{2}]", transactionId, imageName, imageId));
                         usedImageIds.add(imageId);
                     }
                     return imageId;

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/OpenStackInstanceTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/OpenStackInstanceTest.java
@@ -5,7 +5,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openstack4j.api.OSClient;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,13 +18,15 @@ public class OpenStackInstanceTest {
     private PluginSettings settings;
     private OSClient client;
     HashMap<String, String> properties;
+    private Map<String, Object> job1;
 
     @Before
     public void SetUpMocks() {
         client = mock(OSClient.class);
         properties = new HashMap<>();
+        job1 = new HashMap<>();
         settings = new PluginSettings();
-        request = new CreateAgentRequest("abc-key", properties,"testing");
+        request = new CreateAgentRequest("abc-key", properties, job1,"testing");
     }
 
     @Test

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/OpenStackInstancesTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/OpenStackInstancesTest.java
@@ -68,8 +68,8 @@ public class OpenStackInstancesTest {
 
     @Test
     public void matchInstanceShouldReturnTrueWhenRequestHasNoPropertiesButSettingsMatchById() throws Exception {
-        pluginSettings.setOpenstackFlavor(instance.getFlavorId());
-        pluginSettings.setOpenstackImage(instance.getImageId());
+        pluginSettings.setOpenstackFlavor(instance.getFlavorIdOrName());
+        pluginSettings.setOpenstackImage(instance.getImageIdOrName());
         assertThat(instances.matchInstance(instanceId, new HashMap<String, String>(), null, pluginSettings, client, transactionId, false), is(true));
     }
 
@@ -244,16 +244,16 @@ public class OpenStackInstancesTest {
         // Act
         final OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(client);
 
-//        assertEquals(firstImageId, clientWrapper.getImageId(imageName, transactionId));
+//        assertEquals(firstImageId, clientWrapper.getImageIdOrName(imageName, transactionId));
 //        assertEquals("", clientWrapper.getPreviousImageId(imageName, transactionId));
         assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, clientWrapper, transactionId, true), is(true));
 
         when(imageWithName.getId()).thenReturn(secondImageId);
-//        assertEquals(secondImageId, clientWrapper.getImageId(imageName, transactionId));
+//        assertEquals(secondImageId, clientWrapper.getImageIdOrName(imageName, transactionId));
 //        assertEquals(firstImageId, clientWrapper.getPreviousImageId(imageName, transactionId));
 
         // Assert
-//        when(client.getImageId("ubuntu-14", transactionId)).thenReturn("1a248c96-672b-4983-96ed-c3418a4be602");
+//        when(client.getImageIdOrName("ubuntu-14", transactionId)).thenReturn("1a248c96-672b-4983-96ed-c3418a4be602");
 //        when(client.getPreviousImageId("ubuntu-14", transactionId)).thenReturn("7637f039-027d-471f-8d6c-4177635f84f8");
         assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, clientWrapper, transactionId, true), is(true));
         when(imageWithName.getId()).thenReturn(thirdImageId);

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/executors/GetCapabilitiesExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/executors/GetCapabilitiesExecutorTest.java
@@ -1,0 +1,33 @@
+package cd.go.contrib.elasticagents.openstack.executors;
+
+import com.google.gson.Gson;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class GetCapabilitiesExecutorTest {
+    private static final Gson GSON = new Gson();
+    private GetCapabilitiesExecutor executor;
+
+    @Before
+    public void SetUp() {
+        executor = new GetCapabilitiesExecutor();
+    }
+
+
+    @Test
+    public void getCapabilitiesShouldReturnSupportsFields() throws Exception {
+        GoPluginApiResponse response = executor.execute();
+        Map<String, String> responseJson = (Map<String, String>) GSON.fromJson(response.responseBody(), HashMap.class);
+
+        assertThat(responseJson.containsKey("supports_status_report"), is(true));
+        assertThat(responseJson.containsKey("supports_agent_status_report"), is(true));
+    }
+
+}


### PR DESCRIPTION
These are 2 changes:
 - Update to use new elastic agents extension API V3,see https://github.com/gocd/gocd/pull/4470 . **Plugin will now require at least GoCD v18.2**
 - Fixes issue with too many agents being created:

This fixes situations when an agent which is not starting or starting slowly is causing creating more agents. In extreme case when agent's image is broken and does not register, plugin will continue to create instances until hitting hard limit on openstack. Now plugin counts the agents-to-be registered among current agents.
Plugin will also never create an agent if there is already an agent being created for the same job.