### PR TITLE
Three fixes that all adress the issue with job queue is building up for different reasons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # gradle's output dir
 build/
+out/
 
 # the gradle temp dir
 .gradle

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ To build the jar, run `./gradlew clean test assemble`
 2. Example "Plugin Settings"  ( This is the global settings and some properties can be overriden on in the elastic profile )
   * Go Server URL
      * eg. https://your-go-server:8154/go
-  * Agent auto-register (in minutes)*
-     * eg. `30` if you want the agent to live for 30 minutes 
+  * Agent Time To Live minimum (in minutes)*
+     * eg. `30` if you want the agent to live for at least 30 minutes 
+  * Agent Time To Live maximum (in minutes)*
+     * eg. `60` if you want the agent to live a random amount between 30 and 60 minutes 
   * Openstack Endpoint
      * eg. https://your-openstack-public-endpoint:5000/v2.0
   * Openstack Tenant
@@ -41,7 +43,7 @@ To build the jar, run `./gradlew clean test assemble`
      * eg. gocdea
   * Openstack Image (this is the VM image ID or image name from Openstack)
      * eg. `d921abbb-772b-4c96-a150-798506f2a37b`, `ubuntu-16.04`
-  * Openstack Image Cache TTL ( the cache keeps the image ID of the image name  for the given amount of minutes)
+  * Openstack Image Name -> Image ID Cache TTL ( the cache keeps the image ID of the image name  for the given amount of minutes)
      * eg. `30`
   * Allow Use of Previous Openstack Image 
      * if the previous image ID for given image name should be used as fallback
@@ -49,6 +51,8 @@ To build the jar, run `./gradlew clean test assemble`
      * eg `fa8c735b-d477-4649-bb6a-8d58f2052971`, `12234`, `m1.small`
   * Openstack Network (this is the Network ID from Openstack)
     * eg 6d6ceece-6de5-4be5-8a5a-180151f91820
+  * Default Min Instance Limit (only relevant when there is a need for agents of that profile)
+    * eg 2
   * Default Max Instance Limit (for each profile)
     * eg 5
   * Openstack UserData

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To build the jar, run `./gradlew clean test assemble`
   * Go Server URL
      * eg. https://your-go-server:8154/go
   * Agent auto-register (in minutes)*
-     * eg. 30
+     * eg. `30` if you want the agent to live for 30 minutes 
   * Openstack Endpoint
      * eg. https://your-openstack-public-endpoint:5000/v2.0
   * Openstack Tenant
@@ -37,13 +37,17 @@ To build the jar, run `./gradlew clean test assemble`
      * eg. gocdstack
   * Openstack Password
      * eg. gocdstack
-  * Openstack VM Prefix ( this is the prefix added to the VM's hostname to distinguish elastic agent VM to others
+  * Openstack VM Prefix (this is the prefix added to the VM's hostname to distinguish elastic agent VM to others)
      * eg. gocdea
-  * Openstack Image ( this is the VM image ID or image name from Openstack )
+  * Openstack Image (this is the VM image ID or image name from Openstack)
      * eg. `d921abbb-772b-4c96-a150-798506f2a37b`, `ubuntu-16.04`
-  * Openstack Flavor ( this is the Flavor ID or flavor name from Openstack )
+  * Openstack Image Cache TTL ( the cache keeps the image ID of the image name  for the given amount of minutes)
+     * eg. `30`
+  * Allow Use of Previous Openstack Image 
+     * if the previous image ID for given image name should be used as fallback
+  * Openstack Flavor (this is the Flavor ID or flavor name from Openstack)
      * eg `fa8c735b-d477-4649-bb6a-8d58f2052971`, `12234`, `m1.small`
-  * Openstack Network ( this is the Network ID from Openstack )
+  * Openstack Network (this is the Network ID from Openstack)
     * eg 6d6ceece-6de5-4be5-8a5a-180151f91820
   * Default Max Instance Limit (for each profile)
     * eg 5

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'cd.go.contrib'
-version = '0.10.3'
+version = '0.11.0'
 description = 'GoCD OpenStack Elastic Agents'
 
 // these values that go into plugin.xml

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'cd.go.contrib'
-version = '0.10.2'
+version = '0.10.3'
 description = 'GoCD OpenStack Elastic Agents'
 
 // these values that go into plugin.xml

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'cd.go.contrib'
-version = '0.10.0'
+version = '0.10.1'
 description = 'GoCD OpenStack Elastic Agents'
 
 // these values that go into plugin.xml
@@ -33,8 +33,8 @@ project.ext.pluginDesc = [
 ]
 
 // Force 1.7 compatibility to ensure that it works with older JVMs
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 buildDir = "${projectDir}/target"
 
@@ -63,6 +63,8 @@ dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
     compile group: 'commons-codec', name: 'commons-codec', version: '1.10'
+    compile group: 'org.cache2k', name: 'cache2k-api', version: '1.0.2.Final'
+    compile group: 'org.cache2k', name: 'cache2k-core', version: '1.0.2.Final'
 
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
@@ -108,7 +110,7 @@ jar {
     from(configurations.compile) {
         into "lib/"
     }
-    from(sourceSets.main.java){
+    from(sourceSets.main.java) {
         into "/"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'cd.go.contrib'
-version = '0.10.1'
+version = '0.10.2'
 description = 'GoCD OpenStack Elastic Agents'
 
 // these values that go into plugin.xml

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/Constants.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/Constants.java
@@ -56,6 +56,7 @@ public interface Constants {
     String OPENSTACK_USERDATA_ARGS = "openstack_userdata";
     String OPENSTACK_SECURITY_GROUP = "openstack_security_group";
     String OPENSTACK_KEYPAIR = "openstack_keypair";
+    String OPENSTACK_MIN_INSTANCE_LIMIT = "openstack_min_instance_limit";
     String OPENSTACK_MAX_INSTANCE_LIMIT = "openstack_max_instance_limit";
     String OPENSTACK_KEYSTONE_VERSION = "openstack_keystone_ver";
     String OPENSTACK_DOMAIN = "openstack_domain";

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstance.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstance.java
@@ -154,7 +154,7 @@ public class OpenStackInstance {
         ServerCreateBuilder scb = Builders.server()
                 .image(client.getImageId(imageNameOrId, transactionId))
                 .name(instance_name)
-                .flavor(client.getFlavorId(flavorNameOrId))
+                .flavor(client.getFlavorId(flavorNameOrId, transactionId))
                 .networks(Arrays.asList(networkId))
                 .addMetadata(mdata);
         if(encodedUserData != null)

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
@@ -71,7 +71,7 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
     public void refreshAll(PluginRequest pluginRequest) throws Exception {
         if (!refreshed) {
             PluginSettings pluginSettings = pluginRequest.getPluginSettings();
-            if(pluginSettings == null) {
+            if (pluginSettings == null) {
                 LOG.warn("Openstack elastic agents plugin settings are empty");
                 return;
             }
@@ -130,12 +130,7 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
         LOG.debug(format("[{0}] [matchInstance] Request environment [{1}] did match agent's environment: [{2}]", transactionId, requestEnvironment,
                 agentEnvironment));
 
-        String proposedImageIdOrName = properties.get(Constants.OPENSTACK_IMAGE_ID_ARGS);
-        if (StringUtils.isBlank(proposedImageIdOrName)) {
-            LOG.debug("properties do not have image - maybe because elastic profile has blank image and expects image from global settings.");
-            proposedImageIdOrName = pluginSettings.getOpenstackImage();
-        }
-
+        String proposedImageIdOrName = OpenStackInstance.getImageIdOrName(properties, pluginSettings);
 
         LOG.debug(format("[{0}] [matchInstance] Trying to match image name/id: [{1}] with instance image: [{2}]", transactionId,
                 proposedImageIdOrName, instance.getImageIdOrName()));
@@ -163,11 +158,7 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
             }
         }
 
-        String proposedFlavorIdOrName = properties.get(Constants.OPENSTACK_FLAVOR_ID_ARGS);
-        if (StringUtils.isBlank(proposedFlavorIdOrName)) {
-            LOG.debug("properties do not have flavor - maybe because elastic profile has blank flavor and expects flavor from global settings.");
-            proposedFlavorIdOrName = pluginSettings.getOpenstackFlavor();
-        }
+        String proposedFlavorIdOrName = OpenStackInstance.getFlavorIdOrName(properties, pluginSettings);
         LOG.debug(format("[{0}] [matchInstance] Trying to match flavor name: [{1}] with instance flavor: [{2}]", transactionId,
                 proposedFlavorIdOrName, instance.getFlavorIdOrName()));
         if (!proposedFlavorIdOrName.equals(instance.getFlavorIdOrName())) {

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
@@ -173,7 +173,7 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
         if (!proposedFlavorIdOrName.equals(instance.getFlavorIdOrName())) {
             LOG.debug(format("[{0}] [matchInstance] flavor name: [{1}] did NOT match with instance flavor: [{2}]", transactionId,
                     proposedFlavorIdOrName, instance.getFlavorIdOrName()));
-            proposedFlavorIdOrName = client.getFlavorId(proposedFlavorIdOrName);
+            proposedFlavorIdOrName = client.getFlavorId(proposedFlavorIdOrName, transactionId);
             LOG.debug(format("[{0}] [matchInstance] Trying to match flavor name: [{1}] with instance flavor: [{2}]", transactionId,
                     proposedFlavorIdOrName, instance.getFlavorIdOrName()));
             if (!proposedFlavorIdOrName.equals(instance.getFlavorIdOrName())) {

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
@@ -20,7 +20,6 @@ import cd.go.contrib.elasticagents.openstack.requests.CreateAgentRequest;
 import cd.go.contrib.elasticagents.openstack.utils.OpenstackClientWrapper;
 import cd.go.contrib.elasticagents.openstack.utils.Util;
 import com.thoughtworks.go.plugin.api.logging.Logger;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DateUtils;
 import org.joda.time.Period;
 import org.openstack4j.api.OSClient;
@@ -222,8 +221,8 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
                 continue;
             }
 
-            int random = Util.randomPlusMinus(settings.getAgentTTLPlusMinus());
-            int minutesTTL = settings.getAutoRegisterPeriod().getMinutes() + random;
+            LOG.debug(format("[instancesCreatedAfterTimeout] agentTTLMin: [{0}] agentTTLMax: [{1}]", settings.getAutoRegisterPeriod().getMinutes(), settings.getAgentTTLMax()));
+            int minutesTTL = Util.calculateTTL(settings.getAutoRegisterPeriod().getMinutes(), settings.getAgentTTLMax());
             Date expireDate = DateUtils.addMinutes(instance.createAt().toDate(), minutesTTL);
             LOG.debug(format("[instancesCreatedAfterTimeout] Agent: [{0}] with minutesTTL: [{1}]", agent.elasticAgentId(), minutesTTL));
             if (expireDate.before(new Date())) {

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/PluginSettings.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/PluginSettings.java
@@ -51,6 +51,10 @@ public class PluginSettings {
     private String autoRegisterTimeout;
 
     @Expose
+    @SerializedName("default_min_instance_limit")
+    private String defaultMinInstanceLimit;
+
+    @Expose
     @SerializedName("default_max_instance_limit")
     private String defaultMaxInstanceLimit;
 
@@ -113,6 +117,7 @@ public class PluginSettings {
         if (autoRegisterTimeout != null ? !autoRegisterTimeout.equals(that.autoRegisterTimeout) : that.autoRegisterTimeout != null)
             return false;
         if (openstackDomain!= null ? !openstackDomain.equals(that.openstackDomain) : that.openstackDomain!= null) return false;
+        if (defaultMinInstanceLimit != null ? !defaultMinInstanceLimit.equals(that.defaultMinInstanceLimit) : that.defaultMinInstanceLimit != null) return false;
         if (defaultMaxInstanceLimit != null ? !defaultMaxInstanceLimit.equals(that.defaultMaxInstanceLimit) : that.defaultMaxInstanceLimit != null) return false;
         if (openstackTenant!= null ? !openstackTenant.equals(that.openstackTenant) : that.openstackTenant!= null) return false;
         if (openstackUser!= null ? !openstackUser.equals(that.openstackUser) : that.openstackUser!= null) return false;
@@ -133,6 +138,7 @@ public class PluginSettings {
         result = 31 * result + (openstackKeystoneVersion!= null ? openstackKeystoneVersion.hashCode() : 0);
         result = 31 * result + (autoRegisterTimeout != null ? autoRegisterTimeout.hashCode() : 0);
         result = 31 * result + (openstackDomain!= null ? openstackDomain.hashCode() : 0);
+        result = 31 * result + (defaultMinInstanceLimit != null ? defaultMinInstanceLimit.hashCode() : 0);
         result = 31 * result + (defaultMaxInstanceLimit != null ? defaultMaxInstanceLimit.hashCode() : 0);
         result = 31 * result + (openstackTenant!= null ? openstackTenant.hashCode() : 0);
         result = 31 * result + (openstackUser!= null ? openstackUser.hashCode() : 0);
@@ -158,6 +164,13 @@ public class PluginSettings {
             autoRegisterTimeout = "10";
         }
         return autoRegisterTimeout;
+    }
+
+    public String getDefaultMinInstanceLimit() {
+        if (defaultMinInstanceLimit == null) {
+            defaultMinInstanceLimit = "1";
+        }
+        return defaultMinInstanceLimit;
     }
 
     public String getDefaultMaxInstanceLimit() {

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/PluginSettings.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/PluginSettings.java
@@ -54,6 +54,9 @@ public class PluginSettings {
     @SerializedName("default_min_instance_limit")
     private String defaultMinInstanceLimit;
 
+    @SerializedName("agent_ttl_plus_minus")
+    private String agentTTLPlusMinus;
+
     @Expose
     @SerializedName("default_max_instance_limit")
     private String defaultMaxInstanceLimit;
@@ -171,6 +174,20 @@ public class PluginSettings {
             defaultMinInstanceLimit = "1";
         }
         return defaultMinInstanceLimit;
+    }
+
+    public int getAgentTTLPlusMinus() {
+        int result;
+        try {
+            result = Integer.parseInt(agentTTLPlusMinus);
+        } catch (NumberFormatException nfe) {
+            result = 0;
+        }
+        return result;
+    }
+
+    public void setAgentTTLPlusMinus(String agentTTLPlusMinus) {
+        this.agentTTLPlusMinus = agentTTLPlusMinus;
     }
 
     public String getDefaultMaxInstanceLimit() {

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/PluginSettings.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/PluginSettings.java
@@ -51,11 +51,12 @@ public class PluginSettings {
     private String autoRegisterTimeout;
 
     @Expose
+    @SerializedName("agent_ttl_max")
+    private String agentTTLMax;
+
+    @Expose
     @SerializedName("default_min_instance_limit")
     private String defaultMinInstanceLimit;
-
-    @SerializedName("agent_ttl_plus_minus")
-    private String agentTTLPlusMinus;
 
     @Expose
     @SerializedName("default_max_instance_limit")
@@ -115,43 +116,59 @@ public class PluginSettings {
         PluginSettings that = (PluginSettings) o;
 
         if (goServerUrl != null ? !goServerUrl.equals(that.goServerUrl) : that.goServerUrl != null) return false;
-        if (openstackEndpoint!= null ? !openstackEndpoint.equals(that.openstackEndpoint) : that.openstackEndpoint!= null) return false;
-        if (openstackKeystoneVersion!= null ? !openstackKeystoneVersion.equals(that.openstackKeystoneVersion) : that.openstackKeystoneVersion!= null) return false;
+        if (openstackEndpoint != null ? !openstackEndpoint.equals(that.openstackEndpoint) : that.openstackEndpoint != null)
+            return false;
+        if (openstackKeystoneVersion != null ? !openstackKeystoneVersion.equals(that.openstackKeystoneVersion) : that.openstackKeystoneVersion != null)
+            return false;
         if (autoRegisterTimeout != null ? !autoRegisterTimeout.equals(that.autoRegisterTimeout) : that.autoRegisterTimeout != null)
             return false;
-        if (openstackDomain!= null ? !openstackDomain.equals(that.openstackDomain) : that.openstackDomain!= null) return false;
-        if (defaultMinInstanceLimit != null ? !defaultMinInstanceLimit.equals(that.defaultMinInstanceLimit) : that.defaultMinInstanceLimit != null) return false;
-        if (defaultMaxInstanceLimit != null ? !defaultMaxInstanceLimit.equals(that.defaultMaxInstanceLimit) : that.defaultMaxInstanceLimit != null) return false;
-        if (openstackTenant!= null ? !openstackTenant.equals(that.openstackTenant) : that.openstackTenant!= null) return false;
-        if (openstackUser!= null ? !openstackUser.equals(that.openstackUser) : that.openstackUser!= null) return false;
-        if (openstackPassword!= null ? !openstackPassword.equals(that.openstackPassword) : that.openstackPassword!= null) return false;
-        if (openstackVmPrefix!= null ? !openstackVmPrefix.equals(that.openstackVmPrefix) : that.openstackVmPrefix!= null) return false;
-        if (openstackImage!= null ? !openstackImage.equals(that.openstackImage) : that.openstackImage!= null) return false;
-        if (openstackImageCacheTTL!= null ? !openstackImageCacheTTL.equals(that.openstackImageCacheTTL) : that.openstackImageCacheTTL!= null) return false;
-        if (openstackFlavor!= null ? !openstackFlavor.equals(that.openstackFlavor) : that.openstackFlavor!= null) return false;
-        if (openstackNetwork!= null ? !openstackNetwork.equals(that.openstackNetwork) : that.openstackNetwork!= null) return false;
-        return openstackUserdata!= null ? openstackUserdata.equals(that.openstackUserdata) : that.openstackUserdata== null;
+        if (agentTTLMax != null ? !agentTTLMax.equals(that.agentTTLMax) : that.agentTTLMax != null)
+            return false;
+        if (openstackDomain != null ? !openstackDomain.equals(that.openstackDomain) : that.openstackDomain != null)
+            return false;
+        if (defaultMinInstanceLimit != null ? !defaultMinInstanceLimit.equals(that.defaultMinInstanceLimit) : that.defaultMinInstanceLimit != null)
+            return false;
+        if (defaultMaxInstanceLimit != null ? !defaultMaxInstanceLimit.equals(that.defaultMaxInstanceLimit) : that.defaultMaxInstanceLimit != null)
+            return false;
+        if (openstackTenant != null ? !openstackTenant.equals(that.openstackTenant) : that.openstackTenant != null)
+            return false;
+        if (openstackUser != null ? !openstackUser.equals(that.openstackUser) : that.openstackUser != null)
+            return false;
+        if (openstackPassword != null ? !openstackPassword.equals(that.openstackPassword) : that.openstackPassword != null)
+            return false;
+        if (openstackVmPrefix != null ? !openstackVmPrefix.equals(that.openstackVmPrefix) : that.openstackVmPrefix != null)
+            return false;
+        if (openstackImage != null ? !openstackImage.equals(that.openstackImage) : that.openstackImage != null)
+            return false;
+        if (openstackImageCacheTTL != null ? !openstackImageCacheTTL.equals(that.openstackImageCacheTTL) : that.openstackImageCacheTTL != null)
+            return false;
+        if (openstackFlavor != null ? !openstackFlavor.equals(that.openstackFlavor) : that.openstackFlavor != null)
+            return false;
+        if (openstackNetwork != null ? !openstackNetwork.equals(that.openstackNetwork) : that.openstackNetwork != null)
+            return false;
+        return openstackUserdata != null ? openstackUserdata.equals(that.openstackUserdata) : that.openstackUserdata == null;
 
     }
 
     @Override
     public int hashCode() {
         int result = goServerUrl != null ? goServerUrl.hashCode() : 0;
-        result = 31 * result + (openstackEndpoint!= null ? openstackEndpoint.hashCode() : 0);
-        result = 31 * result + (openstackKeystoneVersion!= null ? openstackKeystoneVersion.hashCode() : 0);
+        result = 31 * result + (openstackEndpoint != null ? openstackEndpoint.hashCode() : 0);
+        result = 31 * result + (openstackKeystoneVersion != null ? openstackKeystoneVersion.hashCode() : 0);
         result = 31 * result + (autoRegisterTimeout != null ? autoRegisterTimeout.hashCode() : 0);
-        result = 31 * result + (openstackDomain!= null ? openstackDomain.hashCode() : 0);
+        result = 31 * result + (agentTTLMax != null ? agentTTLMax.hashCode() : 0);
+        result = 31 * result + (openstackDomain != null ? openstackDomain.hashCode() : 0);
         result = 31 * result + (defaultMinInstanceLimit != null ? defaultMinInstanceLimit.hashCode() : 0);
         result = 31 * result + (defaultMaxInstanceLimit != null ? defaultMaxInstanceLimit.hashCode() : 0);
-        result = 31 * result + (openstackTenant!= null ? openstackTenant.hashCode() : 0);
-        result = 31 * result + (openstackUser!= null ? openstackUser.hashCode() : 0);
-        result = 31 * result + (openstackPassword!= null ? openstackPassword.hashCode() : 0);
-        result = 31 * result + (openstackVmPrefix!= null ? openstackVmPrefix.hashCode() : 0);
-        result = 31 * result + (openstackImage!= null ? openstackImage.hashCode() : 0);
-        result = 31 * result + (openstackImageCacheTTL!= null ? openstackImageCacheTTL.hashCode() : 0);
-        result = 31 * result + (openstackFlavor!= null ? openstackFlavor.hashCode() : 0);
-        result = 31 * result + (openstackNetwork!= null ? openstackNetwork.hashCode() : 0);
-        result = 31 * result + (openstackUserdata!= null ? openstackUserdata.hashCode() : 0);
+        result = 31 * result + (openstackTenant != null ? openstackTenant.hashCode() : 0);
+        result = 31 * result + (openstackUser != null ? openstackUser.hashCode() : 0);
+        result = 31 * result + (openstackPassword != null ? openstackPassword.hashCode() : 0);
+        result = 31 * result + (openstackVmPrefix != null ? openstackVmPrefix.hashCode() : 0);
+        result = 31 * result + (openstackImage != null ? openstackImage.hashCode() : 0);
+        result = 31 * result + (openstackImageCacheTTL != null ? openstackImageCacheTTL.hashCode() : 0);
+        result = 31 * result + (openstackFlavor != null ? openstackFlavor.hashCode() : 0);
+        result = 31 * result + (openstackNetwork != null ? openstackNetwork.hashCode() : 0);
+        result = 31 * result + (openstackUserdata != null ? openstackUserdata.hashCode() : 0);
         return result;
     }
 
@@ -176,18 +193,18 @@ public class PluginSettings {
         return defaultMinInstanceLimit;
     }
 
-    public int getAgentTTLPlusMinus() {
+    public int getAgentTTLMax() {
         int result;
         try {
-            result = Integer.parseInt(agentTTLPlusMinus);
+            result = Integer.parseInt(agentTTLMax);
         } catch (NumberFormatException nfe) {
             result = 0;
         }
         return result;
     }
 
-    public void setAgentTTLPlusMinus(String agentTTLPlusMinus) {
-        this.agentTTLPlusMinus = agentTTLPlusMinus;
+    public void setAgentTTLMax(String agentTTLMax) {
+        this.agentTTLMax = agentTTLMax;
     }
 
     public String getDefaultMaxInstanceLimit() {
@@ -206,7 +223,7 @@ public class PluginSettings {
     }
 
     public String getOpenstackKeystoneVersion() {
-        openstackKeystoneVersion =  (openstackKeystoneVersion == null) ? "2" : openstackKeystoneVersion;
+        openstackKeystoneVersion = (openstackKeystoneVersion == null) ? "2" : openstackKeystoneVersion;
         return openstackKeystoneVersion;
     }
 

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/PluginSettings.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/PluginSettings.java
@@ -75,6 +75,10 @@ public class PluginSettings {
     private String openstackImage;
 
     @Expose
+    @SerializedName("openstack_image_cache_ttl")
+    private String openstackImageCacheTTL;
+
+    @Expose
     @SerializedName("use_previous_openstack_image")
     private Boolean usePreviousOpenstackImage;
 
@@ -115,6 +119,7 @@ public class PluginSettings {
         if (openstackPassword!= null ? !openstackPassword.equals(that.openstackPassword) : that.openstackPassword!= null) return false;
         if (openstackVmPrefix!= null ? !openstackVmPrefix.equals(that.openstackVmPrefix) : that.openstackVmPrefix!= null) return false;
         if (openstackImage!= null ? !openstackImage.equals(that.openstackImage) : that.openstackImage!= null) return false;
+        if (openstackImageCacheTTL!= null ? !openstackImageCacheTTL.equals(that.openstackImageCacheTTL) : that.openstackImageCacheTTL!= null) return false;
         if (openstackFlavor!= null ? !openstackFlavor.equals(that.openstackFlavor) : that.openstackFlavor!= null) return false;
         if (openstackNetwork!= null ? !openstackNetwork.equals(that.openstackNetwork) : that.openstackNetwork!= null) return false;
         return openstackUserdata!= null ? openstackUserdata.equals(that.openstackUserdata) : that.openstackUserdata== null;
@@ -134,6 +139,7 @@ public class PluginSettings {
         result = 31 * result + (openstackPassword!= null ? openstackPassword.hashCode() : 0);
         result = 31 * result + (openstackVmPrefix!= null ? openstackVmPrefix.hashCode() : 0);
         result = 31 * result + (openstackImage!= null ? openstackImage.hashCode() : 0);
+        result = 31 * result + (openstackImageCacheTTL!= null ? openstackImageCacheTTL.hashCode() : 0);
         result = 31 * result + (openstackFlavor!= null ? openstackFlavor.hashCode() : 0);
         result = 31 * result + (openstackNetwork!= null ? openstackNetwork.hashCode() : 0);
         result = 31 * result + (openstackUserdata!= null ? openstackUserdata.hashCode() : 0);
@@ -199,6 +205,10 @@ public class PluginSettings {
         return openstackImage;
     }
 
+    public String getOpenstackImageCacheTTL() {
+        return openstackImageCacheTTL;
+    }
+
     public Boolean getUsePreviousOpenstackImage() {
         return usePreviousOpenstackImage;
     }
@@ -245,6 +255,10 @@ public class PluginSettings {
 
     public void setOpenstackImage(String openstackImage) {
         this.openstackImage = openstackImage;
+    }
+
+    public void setOpenstackImageCacheTTL(String openstackImageCacheTTL) {
+        this.openstackImageCacheTTL = openstackImageCacheTTL;
     }
 
     public void setUsePreviousOpenstackImage(Boolean usePreviousOpenstackImage) {

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutor.java
@@ -68,7 +68,7 @@ public class CreateAgentRequestExecutor implements RequestExecutor {
         String requestImageId = OpenStackInstance.getImageIdOrName(request, pluginSettings);
         requestImageId = clientWrapper.getImageId(requestImageId, transactionId);
         String flavorId = OpenStackInstance.getFlavorIdOrName(request, pluginSettings);
-        flavorId = clientWrapper.getFlavorId(flavorId);
+        flavorId = clientWrapper.getFlavorId(flavorId, transactionId);
 
         for(PendingAgent agent : pendingAgentsService.getAgents()) {
             LOG.debug(format("[{0}] [create-agent] Check if pending agent {1} match job profile", transactionId, agent));

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutor.java
@@ -24,6 +24,8 @@ import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import org.apache.commons.lang.StringUtils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static java.text.MessageFormat.format;
@@ -53,9 +55,10 @@ public class CreateAgentRequestExecutor implements RequestExecutor {
         LOG.debug(format("[{0}] [create-agent] {1}", transactionId, request));
 
         int matchingAgentCount = 0;
-        int maxInstanceLimit;
+        List<String> idleAgentsFound = new ArrayList<>();
 
         final String profileMaxLimitStr = request.properties().get(Constants.OPENSTACK_MAX_INSTANCE_LIMIT);
+        int maxInstanceLimit;
         if (StringUtils.isNotBlank(profileMaxLimitStr) && StringUtils.isNumeric(profileMaxLimitStr)) {
             maxInstanceLimit = Integer.parseInt(profileMaxLimitStr);
             LOG.debug(format("[{0}] [create-agent] Using maxInstanceLimit from profile value: {1}", transactionId, request));
@@ -65,22 +68,32 @@ public class CreateAgentRequestExecutor implements RequestExecutor {
         }
 
         PluginSettings pluginSettings = pluginRequest.getPluginSettings();
-        String requestImageId = OpenStackInstance.getImageIdOrName(request, pluginSettings);
+        String requestImageId = OpenStackInstance.getImageIdOrName(request.properties(), pluginSettings);
         requestImageId = clientWrapper.getImageId(requestImageId, transactionId);
-        String flavorId = OpenStackInstance.getFlavorIdOrName(request, pluginSettings);
+        String flavorId = OpenStackInstance.getFlavorIdOrName(request.properties(), pluginSettings);
         flavorId = clientWrapper.getFlavorId(flavorId, transactionId);
 
-        for(PendingAgent agent : pendingAgentsService.getAgents()) {
+        for (PendingAgent agent : pendingAgentsService.getAgents()) {
             LOG.debug(format("[{0}] [create-agent] Check if pending agent {1} match job profile", transactionId, agent));
             AgentMatchResult matchResult = agent.match(transactionId, requestImageId, flavorId, request.environment(), request.job());
-            if(matchResult.isJobMatch()) {
+            if (matchResult.isJobMatch()) {
                 LOG.info(format("[{0}] [create-agent] Will NOT create new instance, agent for job {1} is still being created {2} ", transactionId, request.job(), agent.elasticAgentId()));
                 return new DefaultGoPluginApiResponse(200);
             }
-            if(matchResult.isProfileMatch()) {
+            if (matchResult.isProfileMatch()) {
                 LOG.debug(format("[{0}] [create-agent] found matching pending agent {1} ", transactionId, agent.elasticAgentId()));
                 matchingAgentCount++;
             }
+        }
+
+        final String profileMinLimitStr = request.properties().get(Constants.OPENSTACK_MIN_INSTANCE_LIMIT);
+        int minInstanceLimit;
+        if (StringUtils.isNotBlank(profileMinLimitStr) && StringUtils.isNumeric(profileMinLimitStr)) {
+            minInstanceLimit = Integer.parseInt(profileMinLimitStr);
+            LOG.debug(format("[{0}] [create-agent] Using minInstanceLimit from profile value: {1}", transactionId, request));
+        } else {
+            minInstanceLimit = Integer.parseInt(pluginRequest.getPluginSettings().getDefaultMinInstanceLimit());
+            LOG.debug(format("[{0}] [create-agent] Using minInstanceLimit from default plugin value: {1}", transactionId, request));
         }
 
         for (Agent agent : agents.agents()) {
@@ -90,8 +103,12 @@ public class CreateAgentRequestExecutor implements RequestExecutor {
                 matchingAgentCount++;
                 LOG.debug(format("[{0}] [create-agent] found matching agent {1} ", transactionId, agent.elasticAgentId()));
                 if ((agent.agentState() == Agent.AgentState.Idle)) {
-                    LOG.info(format("[{0}] [create-agent] Will NOT create new instance, found matching idle agent {1} ", transactionId, agent.elasticAgentId()));
-                    return new DefaultGoPluginApiResponse(200);
+                    idleAgentsFound.add(agent.elasticAgentId());
+                    LOG.info(format("[{0}] [create-agent] found {1} matching idle agent {2} ", transactionId, idleAgentsFound, agent.elasticAgentId()));
+                    if (idleAgentsFound.size() >= minInstanceLimit) {
+                        LOG.info(format("[{0}] [create-agent] Will NOT create new instance, found {1} matching idle agent {2} ", transactionId, minInstanceLimit, idleAgentsFound));
+                        return new DefaultGoPluginApiResponse(200);
+                    }
                 }
             }
         }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetPluginConfigurationExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetPluginConfigurationExecutor.java
@@ -39,12 +39,13 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
     public static final Field OPENSTACK_PASSWORD = new NonBlankField("openstack_password", "OpenStack Password", null, true, true, "7");
     public static final Field OPENSTACK_VM_PREFIX = new NonBlankField("openstack_vm_prefix", "OpenStack VM Prefix", null, true, false, "8");
     public static final Field OPENSTACK_IMAGE = new NonBlankField("openstack_image", "OpenStack Image", null, true, false, "9");
-    public static final Field USE_PREVIOUS_OPENSTACK_IMAGE = new NonBlankField("use_previous_openstack_image", "Allow Use of Previous Openstack Image", "false", true, false, "10");
-    public static final Field OPENSTACK_FLAVOR = new NonBlankField("openstack_flavor", "OpenStack Flavor", null, true, false, "11");
-    public static final Field OPENSTACK_NETWORK = new NonBlankField("openstack_network", "OpenStack Network", null, true, false, "12");
+    public static final Field OPENSTACK_IMAGE_CACHE_TTL = new NonBlankField("openstack_image_cache_ttl", "OpenStack Image Cache TTL (in minutes)", "30", true, false, "10");
+    public static final Field USE_PREVIOUS_OPENSTACK_IMAGE = new NonBlankField("use_previous_openstack_image", "Allow Use of Previous Openstack Image", "false", true, false, "11");
+    public static final Field OPENSTACK_FLAVOR = new NonBlankField("openstack_flavor", "OpenStack Flavor", null, true, false, "12");
+    public static final Field OPENSTACK_NETWORK = new NonBlankField("openstack_network", "OpenStack Network", null, true, false, "13");
     public static final Field DEFAULT_MAX_INSTANCE_LIMIT = new PositiveNumberField("default_max_instance_limit", "Default Max Instance Limit", "10", true,
-            false, "13");
-    public static final Field OPENSTACK_USERDATA = new Field("openstack_userdata", "OpenStack Userdata", null, false, false, "14");
+            false, "14");
+    public static final Field OPENSTACK_USERDATA = new Field("openstack_userdata", "OpenStack Userdata", null, false, false, "15");
 
     //public static final Field AGENT_RESOURCES = new Field("resources", "Agent Resources", null, false, false, "11");
     //public static final Field AGENT_ENVIRONMENTS = new Field("environments", "Environments", null, false, false, "12");
@@ -63,6 +64,7 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
         FIELDS.put(OPENSTACK_PASSWORD.key(), OPENSTACK_PASSWORD);
         FIELDS.put(OPENSTACK_VM_PREFIX.key(), OPENSTACK_VM_PREFIX);
         FIELDS.put(OPENSTACK_IMAGE.key(), OPENSTACK_IMAGE);
+        FIELDS.put(OPENSTACK_IMAGE_CACHE_TTL.key(), OPENSTACK_IMAGE_CACHE_TTL);
         FIELDS.put(USE_PREVIOUS_OPENSTACK_IMAGE.key(), USE_PREVIOUS_OPENSTACK_IMAGE);
         FIELDS.put(OPENSTACK_FLAVOR.key(), OPENSTACK_FLAVOR);
         FIELDS.put(OPENSTACK_NETWORK.key(), OPENSTACK_NETWORK);

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetPluginConfigurationExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetPluginConfigurationExecutor.java
@@ -43,9 +43,11 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
     public static final Field USE_PREVIOUS_OPENSTACK_IMAGE = new NonBlankField("use_previous_openstack_image", "Allow Use of Previous Openstack Image", "false", true, false, "11");
     public static final Field OPENSTACK_FLAVOR = new NonBlankField("openstack_flavor", "OpenStack Flavor", null, true, false, "12");
     public static final Field OPENSTACK_NETWORK = new NonBlankField("openstack_network", "OpenStack Network", null, true, false, "13");
-    public static final Field DEFAULT_MAX_INSTANCE_LIMIT = new PositiveNumberField("default_max_instance_limit", "Default Max Instance Limit", "10", true,
+    public static final Field DEFAULT_MIN_INSTANCE_LIMIT = new PositiveNumberField("default_min_instance_limit", "Default Minimum Instance Limit", "1", true,
             false, "14");
-    public static final Field OPENSTACK_USERDATA = new Field("openstack_userdata", "OpenStack Userdata", null, false, false, "15");
+    public static final Field DEFAULT_MAX_INSTANCE_LIMIT = new PositiveNumberField("default_max_instance_limit", "Default Max Instance Limit", "10", true,
+            false, "15");
+    public static final Field OPENSTACK_USERDATA = new Field("openstack_userdata", "OpenStack Userdata", null, false, false, "16");
 
     //public static final Field AGENT_RESOURCES = new Field("resources", "Agent Resources", null, false, false, "11");
     //public static final Field AGENT_ENVIRONMENTS = new Field("environments", "Environments", null, false, false, "12");
@@ -55,6 +57,7 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
     static {
         FIELDS.put(GO_SERVER_URL.key(), GO_SERVER_URL);
         FIELDS.put(AUTOREGISTER_TIMEOUT.key(), AUTOREGISTER_TIMEOUT);
+        FIELDS.put(DEFAULT_MIN_INSTANCE_LIMIT.key(), DEFAULT_MIN_INSTANCE_LIMIT);
         FIELDS.put(DEFAULT_MAX_INSTANCE_LIMIT.key(), DEFAULT_MAX_INSTANCE_LIMIT);
         FIELDS.put(OPENSTACK_ENDPOINT.key(), OPENSTACK_ENDPOINT);
         FIELDS.put(OPENSTACK_KEYSTONE_VERSION.key(), OPENSTACK_KEYSTONE_VERSION);

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetPluginConfigurationExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetPluginConfigurationExecutor.java
@@ -31,23 +31,25 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
     public static final Field GO_SERVER_URL = new NonBlankField("go_server_url", "Go Server URL", null, true, false, "0");
     public static final Field AUTOREGISTER_TIMEOUT = new PositiveNumberField("auto_register_timeout", "Agent auto-register Timeout (in minutes)", "10", true,
             false, "1");
-    public static final Field OPENSTACK_ENDPOINT = new NonBlankField("openstack_endpoint", "OpenStack Endpoint", null, true, false, "2");
-    public static final Field OPENSTACK_KEYSTONE_VERSION = new NonBlankField("openstack_keystone_version", "OpenStack Keystone Version", null, true, false, "3");
-    public static final Field OPENSTACK_DOMAIN = new NonBlankField("openstack_domain", "OpenStack Domain", null, true, false, "4");
-    public static final Field OPENSTACK_TENANT = new NonBlankField("openstack_tenant", "OpenStack Tenant", null, true, false, "5");
-    public static final Field OPENSTACK_USER = new NonBlankField("openstack_user", "OpenStack User", null, true, false, "6");
-    public static final Field OPENSTACK_PASSWORD = new NonBlankField("openstack_password", "OpenStack Password", null, true, true, "7");
-    public static final Field OPENSTACK_VM_PREFIX = new NonBlankField("openstack_vm_prefix", "OpenStack VM Prefix", null, true, false, "8");
-    public static final Field OPENSTACK_IMAGE = new NonBlankField("openstack_image", "OpenStack Image", null, true, false, "9");
-    public static final Field OPENSTACK_IMAGE_CACHE_TTL = new NonBlankField("openstack_image_cache_ttl", "OpenStack Image Cache TTL (in minutes)", "30", true, false, "10");
-    public static final Field USE_PREVIOUS_OPENSTACK_IMAGE = new NonBlankField("use_previous_openstack_image", "Allow Use of Previous Openstack Image", "false", true, false, "11");
-    public static final Field OPENSTACK_FLAVOR = new NonBlankField("openstack_flavor", "OpenStack Flavor", null, true, false, "12");
-    public static final Field OPENSTACK_NETWORK = new NonBlankField("openstack_network", "OpenStack Network", null, true, false, "13");
+    public static final Field AGENT_TTL_PLUS_MINUS = new PositiveNumberField("agent_ttl_plus_minus", "Agent TTL plus minus (in minutes)", "0", true,
+            false, "2");
+    public static final Field OPENSTACK_ENDPOINT = new NonBlankField("openstack_endpoint", "OpenStack Endpoint", null, true, false, "3");
+    public static final Field OPENSTACK_KEYSTONE_VERSION = new NonBlankField("openstack_keystone_version", "OpenStack Keystone Version", null, true, false, "4");
+    public static final Field OPENSTACK_DOMAIN = new NonBlankField("openstack_domain", "OpenStack Domain", null, true, false, "5");
+    public static final Field OPENSTACK_TENANT = new NonBlankField("openstack_tenant", "OpenStack Tenant", null, true, false, "6");
+    public static final Field OPENSTACK_USER = new NonBlankField("openstack_user", "OpenStack User", null, true, false, "7");
+    public static final Field OPENSTACK_PASSWORD = new NonBlankField("openstack_password", "OpenStack Password", null, true, true, "8");
+    public static final Field OPENSTACK_VM_PREFIX = new NonBlankField("openstack_vm_prefix", "OpenStack VM Prefix", null, true, false, "9");
+    public static final Field OPENSTACK_IMAGE = new NonBlankField("openstack_image", "OpenStack Image", null, true, false, "10");
+    public static final Field OPENSTACK_IMAGE_CACHE_TTL = new PositiveNumberField("openstack_image_cache_ttl", "OpenStack Image Cache TTL (in minutes)", "30", true, false, "11");
+    public static final Field USE_PREVIOUS_OPENSTACK_IMAGE = new NonBlankField("use_previous_openstack_image", "Allow Use of Previous Openstack Image", "false", true, false, "12");
+    public static final Field OPENSTACK_FLAVOR = new NonBlankField("openstack_flavor", "OpenStack Flavor", null, true, false, "13");
+    public static final Field OPENSTACK_NETWORK = new NonBlankField("openstack_network", "OpenStack Network", null, true, false, "14");
     public static final Field DEFAULT_MIN_INSTANCE_LIMIT = new PositiveNumberField("default_min_instance_limit", "Default Minimum Instance Limit", "1", true,
-            false, "14");
-    public static final Field DEFAULT_MAX_INSTANCE_LIMIT = new PositiveNumberField("default_max_instance_limit", "Default Max Instance Limit", "10", true,
             false, "15");
-    public static final Field OPENSTACK_USERDATA = new Field("openstack_userdata", "OpenStack Userdata", null, false, false, "16");
+    public static final Field DEFAULT_MAX_INSTANCE_LIMIT = new PositiveNumberField("default_max_instance_limit", "Default Max Instance Limit", "10", true,
+            false, "16");
+    public static final Field OPENSTACK_USERDATA = new Field("openstack_userdata", "OpenStack Userdata", null, false, false, "17");
 
     //public static final Field AGENT_RESOURCES = new Field("resources", "Agent Resources", null, false, false, "11");
     //public static final Field AGENT_ENVIRONMENTS = new Field("environments", "Environments", null, false, false, "12");
@@ -57,6 +59,7 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
     static {
         FIELDS.put(GO_SERVER_URL.key(), GO_SERVER_URL);
         FIELDS.put(AUTOREGISTER_TIMEOUT.key(), AUTOREGISTER_TIMEOUT);
+        FIELDS.put(AGENT_TTL_PLUS_MINUS.key(), AGENT_TTL_PLUS_MINUS);
         FIELDS.put(DEFAULT_MIN_INSTANCE_LIMIT.key(), DEFAULT_MIN_INSTANCE_LIMIT);
         FIELDS.put(DEFAULT_MAX_INSTANCE_LIMIT.key(), DEFAULT_MAX_INSTANCE_LIMIT);
         FIELDS.put(OPENSTACK_ENDPOINT.key(), OPENSTACK_ENDPOINT);

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetPluginConfigurationExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetPluginConfigurationExecutor.java
@@ -31,7 +31,7 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
     public static final Field GO_SERVER_URL = new NonBlankField("go_server_url", "Go Server URL", null, true, false, "0");
     public static final Field AUTOREGISTER_TIMEOUT = new PositiveNumberField("auto_register_timeout", "Agent auto-register Timeout (in minutes)", "10", true,
             false, "1");
-    public static final Field AGENT_TTL_PLUS_MINUS = new PositiveNumberField("agent_ttl_plus_minus", "Agent TTL plus minus (in minutes)", "0", true,
+    public static final Field AGENT_TTL_MAX = new PositiveNumberField("agent_ttl_max", "Agent TTL maximum (in minutes)", "0", true,
             false, "2");
     public static final Field OPENSTACK_ENDPOINT = new NonBlankField("openstack_endpoint", "OpenStack Endpoint", null, true, false, "3");
     public static final Field OPENSTACK_KEYSTONE_VERSION = new NonBlankField("openstack_keystone_version", "OpenStack Keystone Version", null, true, false, "4");
@@ -59,7 +59,7 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
     static {
         FIELDS.put(GO_SERVER_URL.key(), GO_SERVER_URL);
         FIELDS.put(AUTOREGISTER_TIMEOUT.key(), AUTOREGISTER_TIMEOUT);
-        FIELDS.put(AGENT_TTL_PLUS_MINUS.key(), AGENT_TTL_PLUS_MINUS);
+        FIELDS.put(AGENT_TTL_MAX.key(), AGENT_TTL_MAX);
         FIELDS.put(DEFAULT_MIN_INSTANCE_LIMIT.key(), DEFAULT_MIN_INSTANCE_LIMIT);
         FIELDS.put(DEFAULT_MAX_INSTANCE_LIMIT.key(), DEFAULT_MAX_INSTANCE_LIMIT);
         FIELDS.put(OPENSTACK_ENDPOINT.key(), OPENSTACK_ENDPOINT);

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetProfileMetadataExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/GetProfileMetadataExecutor.java
@@ -34,6 +34,7 @@ public class GetProfileMetadataExecutor implements RequestExecutor {
     public static final Metadata OPENSTACK_NETWORK_ID = new Metadata(Constants.OPENSTACK_NETWORK_ID_ARGS, false, false);
     public static final Metadata OPENSTACK_SECURITY_GROUP = new Metadata(Constants.OPENSTACK_SECURITY_GROUP, false, false);
     public static final Metadata OPENSTACK_KEYPAIR = new Metadata(Constants.OPENSTACK_KEYPAIR, false, false);
+    public static final Metadata OPENSTACK_MIN_INSTANCE_LIMIT = new Metadata(Constants.OPENSTACK_MIN_INSTANCE_LIMIT, false, false);
     public static final Metadata OPENSTACK_MAX_INSTANCE_LIMIT = new Metadata(Constants.OPENSTACK_MAX_INSTANCE_LIMIT, false, false);
     public static final Metadata OPENSTACK_USERDATA = new Metadata(Constants.OPENSTACK_USERDATA_ARGS, false, false);
 
@@ -45,6 +46,7 @@ public class GetProfileMetadataExecutor implements RequestExecutor {
         FIELDS.add(OPENSTACK_NETWORK_ID);
         FIELDS.add(OPENSTACK_SECURITY_GROUP);
         FIELDS.add(OPENSTACK_KEYPAIR);
+        FIELDS.add(OPENSTACK_MIN_INSTANCE_LIMIT);
         FIELDS.add(OPENSTACK_MAX_INSTANCE_LIMIT);
         FIELDS.add(OPENSTACK_USERDATA);
     }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/utils/OpenstackClientWrapper.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/utils/OpenstackClientWrapper.java
@@ -4,6 +4,8 @@ import cd.go.contrib.elasticagents.openstack.OpenStackClientFactory;
 import cd.go.contrib.elasticagents.openstack.OpenStackInstance;
 import cd.go.contrib.elasticagents.openstack.PluginSettings;
 import com.thoughtworks.go.plugin.api.logging.Logger;
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
 import org.openstack4j.api.OSClient;
 import org.openstack4j.model.compute.Flavor;
 import org.openstack4j.model.compute.Image;
@@ -12,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import static java.text.MessageFormat.format;
 
@@ -25,12 +28,24 @@ public class OpenstackClientWrapper {
     private final OSClient client;
     private static final Map<String, List<String>> previousImageIds = new ConcurrentHashMap<>();
 
+    private static Cache<String, String> imageCache;
+    private static Cache<String, String> flavorCache;
+    private static int imageCacheTTL = 30;
+
     public OpenstackClientWrapper(OSClient os) {
         this.client = os;
+        initCache(30);
+    }
+
+    public OpenstackClientWrapper(OSClient os, Cache<String, String> imageCache, Cache<String, String> flavorCache) {
+        this.client = os;
+        OpenstackClientWrapper.imageCache = imageCache;
+        OpenstackClientWrapper.flavorCache = flavorCache;
     }
 
     public OpenstackClientWrapper(PluginSettings settings) throws Exception {
         client = OpenStackClientFactory.os_client(settings);
+        initCache(Integer.parseInt(settings.getOpenstackImageCacheTTL()));
     }
 
     public OSClient getClient() {
@@ -38,28 +53,36 @@ public class OpenstackClientWrapper {
     }
 
     public String getImageId(String nameOrId, String transactionId) {
-        LOG.debug(format("[{0}] [getImageIdOrName] nameOrId [{1}]", transactionId, nameOrId));
+        LOG.debug(format("[{0}] [getImageId] nameOrId [{1}]", transactionId, nameOrId));
+        String imageId = imageCache.get(nameOrId);
+        if (imageId != null) {
+            LOG.debug(format("[{0}] [getImageId] found [{1}] with imageId [{2}] in imageCache", transactionId, nameOrId, imageId));
+            return imageId;
+        }
+        LOG.debug(format("[{0}] [getImageId] NOT found [{1}] in imageCache", transactionId, nameOrId));
         Image image = client.compute().images().get(nameOrId);
         if (image == null) {
             for (Image tmpImage : client.compute().images().list()) {
                 String imageName = tmpImage.getName();
-                if (tmpImage.getName() != null && imageName.equals(nameOrId)) {
+                if (imageName != null && imageName.equals(nameOrId)) {
                     if (!previousImageIds.containsKey(imageName)) {
-                        LOG.debug(format("[{0}] [getImageIdOrName] initiate list of previous image is for name [{1}]", transactionId, imageName));
+                        LOG.debug(format("[{0}] [getImageId] initiate list of previous image is for name [{1}]", transactionId, imageName));
                         previousImageIds.put(tmpImage.getName(), new ArrayList<String>());
                     }
                     final List<String> usedImageIds = previousImageIds.get(imageName);
-                    final String imageId = tmpImage.getId();
+                    imageId = tmpImage.getId();
                     if (!usedImageIds.contains(imageId)) {
-                        LOG.debug(format("[{0}] [getImageIdOrName] for image name [{1}] add id [{2}]", transactionId, imageName, imageId));
+                        LOG.debug(format("[{0}] [getImageId] for image name [{1}] add id [{2}]", transactionId, imageName, imageId));
                         usedImageIds.add(imageId);
                     }
+                    imageCache.put(nameOrId, imageId);
                     return imageId;
                 }
             }
             throw new RuntimeException("Failed to find image " + nameOrId);
         } else {
             LOG.warn("Failed to find image by ID " + nameOrId);
+            imageCache.put(nameOrId, nameOrId);
             return nameOrId;
         }
     }
@@ -77,21 +100,51 @@ public class OpenstackClientWrapper {
         return "";
     }
 
-    public String getFlavorId(String flavorNameOrId) {
-        Flavor flavor = client.compute().flavors().get(flavorNameOrId);
+    public String getFlavorId(String nameOrId, String transactionId) {
+        LOG.debug(format("[{0}] [getFlavorId] nameOrId [{1}]", transactionId, nameOrId));
+        String flavorId = flavorCache.get(nameOrId);
+        if (flavorId != null) {
+            LOG.debug(format("[{0}] [getFlavorId] found [{1}] with flavorId [{2}] in flavorCache", transactionId, nameOrId, flavorId));
+            return flavorId;
+        }
+        LOG.debug(format("[{0}] [getFlavorId] NOT found [{1}] in flavorCache", transactionId, nameOrId));
+        Flavor flavor = client.compute().flavors().get(nameOrId);
         if (flavor == null) {
             for (Flavor someFlavor : client.compute().flavors().list()) {
-                if (someFlavor.getName().equals(flavorNameOrId))
+                String flavorName = someFlavor.getName();
+                if (flavorName != null && flavorName.equals(nameOrId)) {
+                    flavorCache.put(flavorName, someFlavor.getId());
                     return someFlavor.getId();
+                }
             }
-            throw new RuntimeException("Failed to find flavor by name " + flavorNameOrId);
+            throw new RuntimeException("Failed to find flavor by name " + nameOrId);
         } else {
-            LOG.warn("Failed to find flavor by ID " + flavorNameOrId);
-            return flavorNameOrId;
+            LOG.warn("Failed to find flavor by ID " + nameOrId);
+            return nameOrId;
         }
     }
 
     public void resetPreviousImages() {
         previousImageIds.clear();
+    }
+
+    private void initCache(int minutesTTL) {
+
+        if (OpenstackClientWrapper.imageCache == null || imageCacheTTL != minutesTTL) {
+            LOG.info(format("[initCache] with TTL [{0}] minutes", minutesTTL));
+            OpenstackClientWrapper.imageCacheTTL = minutesTTL;
+            OpenstackClientWrapper.imageCache = new Cache2kBuilder<String, String>() {
+            }
+                    .expireAfterWrite(minutesTTL, TimeUnit.MINUTES)
+                    .entryCapacity(100)
+                    .build();
+
+            OpenstackClientWrapper.flavorCache = new Cache2kBuilder<String, String>() {
+            }
+                    .expireAfterWrite(24, TimeUnit.HOURS)
+                    .entryCapacity(100)
+                    .build();
+
+        }
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/utils/Util.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/utils/Util.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.util.Properties;
+import java.util.Random;
 
 public class Util {
 
@@ -58,5 +59,17 @@ public class Util {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * E.g. if 10 is given, a random value between -10 and 10 should be returned.
+     *
+     * @param plusminus int to have as limit on max and min of random int.
+     * @return A random int based on given plusminus int.
+     */
+    public static int randomPlusMinus(int plusminus) {
+        Random rand = new Random();
+        int random = rand.nextInt(plusminus + plusminus + 1) - plusminus;
+        return random;
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/utils/Util.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/utils/Util.java
@@ -62,14 +62,19 @@ public class Util {
     }
 
     /**
-     * E.g. if 10 is given, a random value between -10 and 10 should be returned.
+     * E.g. if agentMinTTL 10 and agentMaxTTL 20 is given, a random value between 10 and 20 should be returned.
      *
-     * @param plusminus int to have as limit on max and min of random int.
-     * @return A random int based on given plusminus int.
+     * @param agentMinTTL positive int
+     * @param agentMaxTTL positive int
+     * @return Random value between agentMinTTL and agentMaxTTL or at least agentMinTTL minutes.
      */
-    public static int randomPlusMinus(int plusminus) {
+    public static int calculateTTL(int agentMinTTL, int agentMaxTTL) {
+        if (agentMaxTTL < agentMinTTL)
+            return agentMinTTL;
         Random rand = new Random();
-        int random = rand.nextInt(plusminus + plusminus + 1) - plusminus;
-        return random;
+        int result;
+        int random = agentMaxTTL - agentMinTTL;
+        result = agentMinTTL + rand.nextInt(random + 1);
+        return result;
     }
 }

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -21,15 +21,15 @@
 </div>
 
 <div class="form_item_block">
-  <label>Agent Time to live (E.g. 30 minutes)<span class='asterix'>*</span></label>
+  <label>Agent Time To Live minimum (E.g. 30 minutes)<span class='asterix'>*</span></label>
   <input type="text" ng-model="auto_register_timeout" ng-required="true" placeholder="30"/>
   <span class="form_error" ng-show="GOINPUTNAME[auto_register_timeout].$error.server">{{ GOINPUTNAME[auto_register_timeout].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Agent TTL plus minus random amount of minutes (E.g. 30 +/- 10 results in between 20 and 40 minutes)<span class='asterix'>*</span></label>
-  <input type="text" ng-model="agent_ttl_plus_minus" ng-required="true"/>
-  <span class="form_error" ng-show="GOINPUTNAME[agent_ttl_plus_minus].$error.server">{{ GOINPUTNAME[agent_ttl_plus_minus].$error.server}}</span>
+  <label>Agent Time To Live maximum (A random TTL between minimum and maximum will be generated, e.g. min 30 and max 60 results in between 30 and 60 minutes)<span class='asterix'>*</span></label>
+  <input type="text" ng-model="agent_ttl_max" ng-required="true" placeholder="60" />
+  <span class="form_error" ng-show="GOINPUTNAME[agent_ttl_max].$error.server">{{ GOINPUTNAME[agent_ttl_max].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
@@ -106,13 +106,13 @@
 </div>
 
 <div class="form_item_block">
-  <label>Default Minimum Instance Limit (for each profile)<span class='asterix'>*</span></label>
+  <label>Default minimum instance limit (only relevant when there is a need for agents of that profile)<span class='asterix'>*</span></label>
   <input type="text" ng-model="default_min_instance_limit" ng-required="true" placeholder="1"/>
   <span class="form_error" ng-show="GOINPUTNAME[default_min_instance_limit].$error.server">{{ GOINPUTNAME[default_min_instance_limit].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Default Max Instance Limit (for each profile)<span class='asterix'>*</span></label>
+  <label>Default maximum instance limit (for each profile)<span class='asterix'>*</span></label>
   <input type="text" ng-model="default_max_instance_limit" ng-required="true" placeholder="10"/>
   <span class="form_error" ng-show="GOINPUTNAME[default_max_instance_limit].$error.server">{{ GOINPUTNAME[default_max_instance_limit].$error.server}}</span>
 </div>

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -100,8 +100,14 @@
 </div>
 
 <div class="form_item_block">
+  <label>Default Minimum Instance Limit (for each profile)<span class='asterix'>*</span></label>
+  <input type="text" ng-model="default_min_instance_limit" ng-required="true" placeholder="1"/>
+  <span class="form_error" ng-show="GOINPUTNAME[default_min_instance_limit].$error.server">{{ GOINPUTNAME[default_min_instance_limit].$error.server}}</span>
+</div>
+
+<div class="form_item_block">
   <label>Default Max Instance Limit (for each profile)<span class='asterix'>*</span></label>
-  <input type="text" ng-model="default_max_instance_limit" ng-required="true"/>
+  <input type="text" ng-model="default_max_instance_limit" ng-required="true" placeholder="10"/>
   <span class="form_error" ng-show="GOINPUTNAME[default_max_instance_limit].$error.server">{{ GOINPUTNAME[default_max_instance_limit].$error.server}}</span>
 </div>
 

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -75,6 +75,12 @@
 </div>
 
 <div class="form_item_block">
+  <label>Openstack Image Cache TTL (in minutes)<span class='asterix'>*</span></label>
+  <input type="text" ng-model="openstack_image_cache_ttl" ng-required="true"/>
+  <span class="form_error" ng-show="GOINPUTNAME[openstack_image_cache_ttl].$error.server">{{ GOINPUTNAME[openstack_image_cache_ttl].$error.server}}</span>
+</div>
+
+<div class="form_item_block">
   <label>Allow Use of Previous Openstack Image</label>
   <input type="radio" ng-model="use_previous_openstack_image" value="true"/> True
   <input type="radio" ng-model="use_previous_openstack_image" value="false"/> False

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -21,13 +21,19 @@
 </div>
 
 <div class="form_item_block">
-  <label>Agent Time to live (in minutes)<span class='asterix'>*</span></label>
-  <input type="text" ng-model="auto_register_timeout" ng-required="true"/>
+  <label>Agent Time to live (E.g. 30 minutes)<span class='asterix'>*</span></label>
+  <input type="text" ng-model="auto_register_timeout" ng-required="true" placeholder="30"/>
   <span class="form_error" ng-show="GOINPUTNAME[auto_register_timeout].$error.server">{{ GOINPUTNAME[auto_register_timeout].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Openstack Endpoint<span class='asterix'>*</span></label>
+  <label>Agent TTL plus minus random amount of minutes (E.g. 30 +/- 10 results in between 20 and 40 minutes)<span class='asterix'>*</span></label>
+  <input type="text" ng-model="agent_ttl_plus_minus" ng-required="true"/>
+  <span class="form_error" ng-show="GOINPUTNAME[agent_ttl_plus_minus].$error.server">{{ GOINPUTNAME[agent_ttl_plus_minus].$error.server}}</span>
+</div>
+
+<div class="form_item_block">
+  <label>Openstack Endpoint URL<span class='asterix'>*</span></label>
   <input type="text" ng-model="openstack_endpoint" ng-required="true"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_endpoint].$error.server">{{ GOINPUTNAME[openstack_endpoint].$error.server}}</span>
 </div>
@@ -75,13 +81,13 @@
 </div>
 
 <div class="form_item_block">
-  <label>Openstack Image Cache TTL (in minutes)<span class='asterix'>*</span></label>
-  <input type="text" ng-model="openstack_image_cache_ttl" ng-required="true"/>
+  <label>Openstack Image Name -> Image ID Cache TTL (in minutes)<span class='asterix'>*</span></label>
+  <input type="text" ng-model="openstack_image_cache_ttl" ng-required="true" placeholder="30"/>
   <span class="form_error" ng-show="GOINPUTNAME[openstack_image_cache_ttl].$error.server">{{ GOINPUTNAME[openstack_image_cache_ttl].$error.server}}</span>
 </div>
 
 <div class="form_item_block">
-  <label>Allow Use of Previous Openstack Image</label>
+  <label>Allow Use of Previous Openstack Image ID when Image Name has been updated with new Image ID</label>
   <input type="radio" ng-model="use_previous_openstack_image" value="true"/> True
   <input type="radio" ng-model="use_previous_openstack_image" value="false"/> False
   <span class="form_error" ng-show="GOINPUTNAME[use_previous_openstack_image].$error.server">{{ GOINPUTNAME[use_previous_openstack_image].$error.server}}</span>

--- a/src/main/resources/profile.template.html
+++ b/src/main/resources/profile.template.html
@@ -45,7 +45,7 @@
 </div>
 
 <div class="form_item_block">
-    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_min_instance_limit].$error.server}">Minimum Instance Limit</label>
+    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_min_instance_limit].$error.server}">Minimum Instance Limit (only relevant when there is a need for agents of this profile)</label>
     <input ng-class="{'is-invalid-input': GOINPUTNAME[openstack_min_instance_limit].$error.server}" type="text" ng-model="openstack_min_instance_limit" ng-required="false" placeholder="1"/>
     <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[openstack_min_instance_limit].$error.server}" ng-show="GOINPUTNAME[openstack_min_instance_limit].$error.server">{{GOINPUTNAME[openstack_min_instance_limit].$error.server}}</span>
 </div>

--- a/src/main/resources/profile.template.html
+++ b/src/main/resources/profile.template.html
@@ -45,6 +45,12 @@
 </div>
 
 <div class="form_item_block">
+    <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_min_instance_limit].$error.server}">Minimum Instance Limit</label>
+    <input ng-class="{'is-invalid-input': GOINPUTNAME[openstack_min_instance_limit].$error.server}" type="text" ng-model="openstack_min_instance_limit" ng-required="false" placeholder="1"/>
+    <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[openstack_min_instance_limit].$error.server}" ng-show="GOINPUTNAME[openstack_min_instance_limit].$error.server">{{GOINPUTNAME[openstack_min_instance_limit].$error.server}}</span>
+</div>
+
+<div class="form_item_block">
     <label ng-class="{'is-invalid-label': GOINPUTNAME[openstack_max_instance_limit].$error.server}">Max Instance Limit</label>
     <input ng-class="{'is-invalid-input': GOINPUTNAME[openstack_max_instance_limit].$error.server}" type="text" ng-model="openstack_max_instance_limit" ng-required="false" placeholder="10"/>
     <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[openstack_max_instance_limit].$error.server}" ng-show="GOINPUTNAME[openstack_max_instance_limit].$error.server">{{GOINPUTNAME[openstack_max_instance_limit].$error.server}}</span>

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/OpenStackInstancesTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/OpenStackInstancesTest.java
@@ -1,6 +1,8 @@
 package cd.go.contrib.elasticagents.openstack;
 
 import cd.go.contrib.elasticagents.openstack.utils.OpenstackClientWrapper;
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
 import org.junit.Before;
 import org.junit.Test;
 import org.openstack4j.api.OSClient;
@@ -11,14 +13,12 @@ import org.openstack4j.model.compute.Flavor;
 import org.openstack4j.model.compute.Image;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class OpenStackInstancesTest {
     private OpenStackInstances instances;
@@ -46,15 +46,15 @@ public class OpenStackInstancesTest {
         pluginSettings.setOpenstackTenant("tenant");
         pluginSettings.setOpenstackVmPrefix("prefix-");
 
-        when(client.getFlavorId("default-flavor")).thenReturn("a883873b-d568-4c1a-bee5-9806996e3a02");
+        when(client.getFlavorId("default-flavor", transactionId)).thenReturn("a883873b-d568-4c1a-bee5-9806996e3a02");
 
         /*
         In tests we assume that
         - image 7637f039-027d-471f-8d6c-4177635f84f8 is called 'ubuntu-14'
         - flavor c1980bb5-ed59-4573-83c9-8391b53b3a55 is called 'm1.small'
          */
-        when(client.getFlavorId("c1980bb5-ed59-4573-83c9-8391b53b3a55")).thenReturn("c1980bb5-ed59-4573-83c9-8391b53b3a55");
-        when(client.getFlavorId("m1.small")).thenReturn("c1980bb5-ed59-4573-83c9-8391b53b3a55");
+        when(client.getFlavorId("c1980bb5-ed59-4573-83c9-8391b53b3a55", transactionId)).thenReturn("c1980bb5-ed59-4573-83c9-8391b53b3a55");
+        when(client.getFlavorId("m1.small", transactionId)).thenReturn("c1980bb5-ed59-4573-83c9-8391b53b3a55");
         when(client.getImageId("7637f039-027d-471f-8d6c-4177635f84f8", transactionId)).thenReturn("7637f039-027d-471f-8d6c-4177635f84f8");
         when(client.getImageId("ubuntu-14", transactionId)).thenReturn("7637f039-027d-471f-8d6c-4177635f84f8");
     }
@@ -108,7 +108,7 @@ public class OpenStackInstancesTest {
         HashMap<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "5db97077-b9f0-46f9-a992-15708ad3b83d");
-        when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
+        when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d", transactionId)).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
         assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client, transactionId, false), is(false));
     }
 
@@ -122,7 +122,7 @@ public class OpenStackInstancesTest {
         HashMap<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
-        when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
+        when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d", transactionId)).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
         assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client, transactionId, false), is(false));
     }
 
@@ -145,7 +145,7 @@ public class OpenStackInstancesTest {
         HashMap<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
-        when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
+        when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d", transactionId)).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
         assertThat(instances.matchInstance(instanceId, properties, "testing", pluginSettings, client, transactionId, false), is(true));
     }
 
@@ -159,7 +159,7 @@ public class OpenStackInstancesTest {
         HashMap<String, String> properties = new HashMap<>();
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, "7637f039-027d-471f-8d6c-4177635f84f8");
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, "c1980bb5-ed59-4573-83c9-8391b53b3a55");
-        when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d")).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
+        when(client.getFlavorId("5db97077-b9f0-46f9-a992-15708ad3b83d", transactionId)).thenReturn("5db97077-b9f0-46f9-a992-15708ad3b83d");
         assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, client, transactionId, false), is(true));
     }
 
@@ -197,8 +197,8 @@ public class OpenStackInstancesTest {
 
     @Test
     public void matchInstanceShouldReturnTrueWhenFallbackImageIsUsedFromPluginSettings() throws Exception {
-        // Arrange
 
+        // Arrange
         final String imageName = "ubuntu-14";
         String firstImageId = "firstImageId";
         String secondImageId = "secondImageId";
@@ -241,23 +241,24 @@ public class OpenStackInstancesTest {
         properties.put(Constants.OPENSTACK_IMAGE_ID_ARGS, imageName);
         properties.put(Constants.OPENSTACK_FLAVOR_ID_ARGS, flavorId);
 
+        Cache<String, String> cache = new Cache2kBuilder<String, String>() {
+        }
+                .expireAfterWrite(1, TimeUnit.SECONDS)
+                .entryCapacity(100)
+                .build();
+
         // Act
-        final OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(client);
-
-//        assertEquals(firstImageId, clientWrapper.getImageIdOrName(imageName, transactionId));
-//        assertEquals("", clientWrapper.getPreviousImageId(imageName, transactionId));
+        final OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(client, cache, null);
         assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, clientWrapper, transactionId, true), is(true));
+        cache.clear();
 
-        when(imageWithName.getId()).thenReturn(secondImageId);
-//        assertEquals(secondImageId, clientWrapper.getImageIdOrName(imageName, transactionId));
-//        assertEquals(firstImageId, clientWrapper.getPreviousImageId(imageName, transactionId));
 
         // Assert
-//        when(client.getImageIdOrName("ubuntu-14", transactionId)).thenReturn("1a248c96-672b-4983-96ed-c3418a4be602");
-//        when(client.getPreviousImageId("ubuntu-14", transactionId)).thenReturn("7637f039-027d-471f-8d6c-4177635f84f8");
+        when(imageWithName.getId()).thenReturn(secondImageId);
         assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, clientWrapper, transactionId, true), is(true));
-        when(imageWithName.getId()).thenReturn(thirdImageId);
+        cache.clear();
 
+        when(imageWithName.getId()).thenReturn(thirdImageId);
         assertThat(instances.matchInstance(instanceId, properties, null, pluginSettings, clientWrapper, transactionId, true), is(false));
 
     }

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/executors/CreateAgentRequestExecutorTest.java
@@ -49,11 +49,11 @@ public class CreateAgentRequestExecutorTest {
         osInstance = mock(OpenStackInstance.class);
         when(osInstance.getImageIdOrName()).thenReturn(IMAGE_ID);
         when(osInstance.getFlavorIdOrName()).thenReturn(FLAVOR_ID);
-        when(openstackClientWrapper.getImageId(anyString(),anyString())).thenReturn(IMAGE_ID);
-        when(openstackClientWrapper.getFlavorId(anyString())).thenReturn(FLAVOR_ID);
-        job1 =  new HashMap<>();
+        when(openstackClientWrapper.getImageId(anyString(), anyString())).thenReturn(IMAGE_ID);
+        when(openstackClientWrapper.getFlavorId(anyString(), anyString())).thenReturn(FLAVOR_ID);
+        job1 = new HashMap<>();
         populateJobFields(job1);
-        job2 =  new HashMap<>();
+        job2 = new HashMap<>();
         populateJobFields(job2);
         job2.put("job_id", 101);
     }

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/utils/OpenstackClientWrapperTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/utils/OpenstackClientWrapperTest.java
@@ -1,14 +1,19 @@
 package cd.go.contrib.elasticagents.openstack.utils;
 
+import org.cache2k.Cache;
+import org.cache2k.Cache2kBuilder;
 import org.junit.Test;
 import org.openstack4j.api.OSClient;
 import org.openstack4j.api.compute.ComputeImageService;
 import org.openstack4j.api.compute.ComputeService;
+import org.openstack4j.api.compute.FlavorService;
+import org.openstack4j.model.compute.Flavor;
 import org.openstack4j.model.compute.Image;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -82,9 +87,13 @@ public class OpenstackClientWrapperTest {
         images.add(imageWithName);
 
         doReturn(images).when(imageService).list();
+        Cache<String, String> cache = new Cache2kBuilder<String, String>() {
+        }
+                .entryCapacity(100)
+                .build();
 
         // Act
-        final OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(client);
+        final OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(client, cache, null);
         clientWrapper.resetPreviousImages();
 
         // Assert
@@ -92,11 +101,114 @@ public class OpenstackClientWrapperTest {
         assertEquals("", clientWrapper.getPreviousImageId(imageName, transactionId));
 
         when(imageWithName.getId()).thenReturn(secondImageId);
+        cache.clear();
         assertEquals(secondImageId, clientWrapper.getImageId(imageName, transactionId));
         assertEquals(firstImageId, clientWrapper.getPreviousImageId(imageName, transactionId));
 
         when(imageWithName.getId()).thenReturn(thirdImageId);
+        cache.clear();
         assertEquals(thirdImageId, clientWrapper.getImageId(imageName, transactionId));
         assertEquals(secondImageId, clientWrapper.getPreviousImageId(imageName, transactionId));
+    }
+
+    @Test
+    public void testImageIdCache() throws Exception {
+        // Arrange
+        String imageName = "ImageName";
+        String expectedImageId = "ImageId";
+        OSClient client = mock(OSClient.class);
+        final ComputeService compute = mock(ComputeService.class);
+        when(client.compute()).thenReturn(compute);
+        final ComputeImageService imageService = mock(ComputeImageService.class);
+        when(compute.images()).thenReturn(imageService);
+
+        when(imageService.get(anyString())).thenReturn(null);
+
+        List<Image> images = new ArrayList<>();
+        Image imageWithNullName = mock(Image.class);
+        when(imageWithNullName.getName()).thenReturn(null);
+        when(imageWithNullName.getId()).thenReturn("imageWithNullNameId");
+        images.add(imageWithNullName);
+
+        Image imageWithName = mock(Image.class);
+        when(imageWithName.getName()).thenReturn(imageName);
+        when(imageWithName.getId()).thenReturn(expectedImageId);
+        images.add(imageWithName);
+
+        doReturn(images).when(imageService).list();
+
+        Cache<String, String> cache = new Cache2kBuilder<String, String>() {
+        }
+                .expireAfterWrite(1, TimeUnit.SECONDS)
+                .entryCapacity(100)
+                .build();
+
+        // Act
+        final OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(client, cache, null);
+
+        // Assert
+        verify(imageService, times(0)).list();
+        //final String imageId = clientWrapper.getImageId(imageName, transactionId);
+        assertEquals(expectedImageId, clientWrapper.getImageId(imageName, transactionId));
+        verify(imageService, times(1)).list();
+        assertEquals(expectedImageId, clientWrapper.getImageId(imageName, transactionId));
+        verify(imageService, times(1)).list();
+        System.out.println("sleep 1000");
+        Thread.sleep(1000);
+        assertEquals(expectedImageId, clientWrapper.getImageId(imageName, transactionId));
+        verify(imageService, times(2)).list();
+        assertEquals(expectedImageId, clientWrapper.getImageId(imageName, transactionId));
+        verify(imageService, times(2)).list();
+
+    }
+
+    @Test
+    public void testFlavorIdCache() throws Exception {
+        // Arrange
+        String flavorName = "m1.medium";
+        String expectedFlavorId = "289349234";
+        OSClient client = mock(OSClient.class);
+        final ComputeService compute = mock(ComputeService.class);
+        when(client.compute()).thenReturn(compute);
+        final FlavorService flavorService = mock(FlavorService.class);
+        when(compute.flavors()).thenReturn(flavorService);
+
+        when(flavorService.get(anyString())).thenReturn(null);
+
+        List<Flavor> flavors = new ArrayList<>();
+        Flavor flavorWithNullName = mock(Flavor.class);
+        when(flavorWithNullName.getName()).thenReturn(null);
+        when(flavorWithNullName.getId()).thenReturn("flavorWithNullNameId");
+        flavors.add(flavorWithNullName);
+
+        Flavor flavorWithName = mock(Flavor.class);
+        when(flavorWithName.getName()).thenReturn(flavorName);
+        when(flavorWithName.getId()).thenReturn(expectedFlavorId);
+        flavors.add(flavorWithName);
+
+        doReturn(flavors).when(flavorService).list();
+
+        Cache<String, String> cache = new Cache2kBuilder<String, String>() {
+        }
+                .expireAfterWrite(1, TimeUnit.SECONDS)
+                .entryCapacity(100)
+                .build();
+
+        // Act
+        final OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(client, null, cache);
+
+        // Assert
+        verify(flavorService, times(0)).list();
+        //final String flavorId = clientWrapper.getFlavorId(flavorName, transactionId);
+        assertEquals(expectedFlavorId, clientWrapper.getFlavorId(flavorName, transactionId));
+        verify(flavorService, times(1)).list();
+        assertEquals(expectedFlavorId, clientWrapper.getFlavorId(flavorName, transactionId));
+        verify(flavorService, times(1)).list();
+        System.out.println("sleep 1000");
+        Thread.sleep(1000);
+        assertEquals(expectedFlavorId, clientWrapper.getFlavorId(flavorName, transactionId));
+        verify(flavorService, times(2)).list();
+        assertEquals(expectedFlavorId, clientWrapper.getFlavorId(flavorName, transactionId));
+        verify(flavorService, times(2)).list();
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/utils/UtilTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/utils/UtilTest.java
@@ -2,47 +2,33 @@ package cd.go.contrib.elasticagents.openstack.utils;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class UtilTest {
 
     @Test
-    public void testRandom() throws Exception {
+    public void testShouldReturnTimeToLiveBetween10And20Minutes() {
         // Arrange
-        int max = 5;
-        int min = -5;
-
-        // Act
+        int min = 10;
+        int max = 20;
 
         // Assert
-        boolean minusValueFound = false;
         for (int i = 0; i < 100; i++) {
-            int value = Util.randomPlusMinus(max);
+            int value = Util.calculateTTL(min, max);
             System.out.println(value);
             assertTrue("Should be max " + max, max >= value);
             assertTrue("Should be min " + min, min <= value);
-            if (value < 0) {
-                minusValueFound = true;
-            }
         }
-        assertTrue("Should find at least one minus value", minusValueFound);
-
     }
 
     @Test
-    public void testRandomZero() throws Exception {
-        // Arrange
-        int max = 0;
-        int min = 0;
-
-        // Act
+    public void testShouldReturnTimeToLiveNoLessThanMinimum() {
 
         // Assert
-        for (int i = 0; i < 100; i++) {
-            int value = Util.randomPlusMinus(max);
-            System.out.println(value);
-            assertTrue("Should be max " + max, max >= value);
-            assertTrue("Should be min " + min, min <= value);
-        }
+        assertEquals("Should be no less than minimum", 10, Util.calculateTTL(10, 0));
+        assertEquals("Should be no less than minimum", 10, Util.calculateTTL(10, 5));
+        assertEquals("Should be no less than minimum", 10, Util.calculateTTL(10, 10));
+        assertEquals("Should be no less than minimum", 10, Util.calculateTTL(10, -11));
     }
 }

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/utils/UtilTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/utils/UtilTest.java
@@ -1,0 +1,48 @@
+package cd.go.contrib.elasticagents.openstack.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class UtilTest {
+
+    @Test
+    public void testRandom() throws Exception {
+        // Arrange
+        int max = 5;
+        int min = -5;
+
+        // Act
+
+        // Assert
+        boolean minusValueFound = false;
+        for (int i = 0; i < 100; i++) {
+            int value = Util.randomPlusMinus(max);
+            System.out.println(value);
+            assertTrue("Should be max " + max, max >= value);
+            assertTrue("Should be min " + min, min <= value);
+            if (value < 0) {
+                minusValueFound = true;
+            }
+        }
+        assertTrue("Should find at least one minus value", minusValueFound);
+
+    }
+
+    @Test
+    public void testRandomZero() throws Exception {
+        // Arrange
+        int max = 0;
+        int min = 0;
+
+        // Act
+
+        // Assert
+        for (int i = 0; i < 100; i++) {
+            int value = Util.randomPlusMinus(max);
+            System.out.println(value);
+            assertTrue("Should be max " + max, max >= value);
+            assertTrue("Should be min " + min, min <= value);
+        }
+    }
+}


### PR DESCRIPTION
- Added cache for calls to OpenStack API that took at least 0,5 seconds each, which saves us about 60 minutes of API calls every minute at peak hours. 
- Make it possible to spin up more agents than needed at the moment.
- Add random termination of agents within given range to spread out the termination and recreation.