### PR TITLE
Fix issue which caused the cache to be instantiated continuously.

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackClientFactory.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackClientFactory.java
@@ -29,7 +29,7 @@ public class OpenStackClientFactory {
     private static OSClient client;
     private static PluginSettings pluginSettings;
 
-    public static synchronized OSClient os_client(PluginSettings pluginSettings) throws Exception {
+    public static synchronized OSClient os_client(PluginSettings pluginSettings) {
         if (pluginSettings.equals(OpenStackClientFactory.pluginSettings) && OpenStackClientFactory.client != null) {
             if (OpenStackClientFactory.client.getToken().getExpires().after(new Date(System.currentTimeMillis() + 5 * 60 * 1000))) {
                 LOG.debug("OpenStackClientFactory - token is still valid : " + OpenStackClientFactory.client.getToken().getExpires().toString());
@@ -49,7 +49,7 @@ public class OpenStackClientFactory {
         return config;
     }
 
-    private static OSClient createClient(PluginSettings pluginSettings) throws Exception {
+    private static OSClient createClient(PluginSettings pluginSettings) {
         if (OpenStackClientFactory.client == null) {
             LOG.debug("OpenStackClientFactory - get new token from OpenStack");
         } else {

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstance.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstance.java
@@ -151,7 +151,7 @@ public class OpenStackInstance {
         LOG.debug(request.properties().toString());
 
         final String encodedUserData = getEncodedUserData(request, settings);
-        OpenstackClientWrapper client = new OpenstackClientWrapper(osclient);
+        OpenstackClientWrapper client = new OpenstackClientWrapper(settings);
         String imageNameOrId = getImageIdOrName(request.properties(), settings);
         imageNameOrId = client.getImageId(imageNameOrId, transactionId);
         String flavorNameOrId = getFlavorIdOrName(request.properties(), settings);

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/utils/OpenstackClientWrapper.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/utils/OpenstackClientWrapper.java
@@ -32,18 +32,13 @@ public class OpenstackClientWrapper {
     private static Cache<String, String> flavorCache;
     private static int imageCacheTTL = 30;
 
-    public OpenstackClientWrapper(OSClient os) {
-        this.client = os;
-        initCache(30);
-    }
-
     public OpenstackClientWrapper(OSClient os, Cache<String, String> imageCache, Cache<String, String> flavorCache) {
         this.client = os;
         OpenstackClientWrapper.imageCache = imageCache;
         OpenstackClientWrapper.flavorCache = flavorCache;
     }
 
-    public OpenstackClientWrapper(PluginSettings settings) throws Exception {
+    public OpenstackClientWrapper(PluginSettings settings) {
         client = OpenStackClientFactory.os_client(settings);
         initCache(Integer.parseInt(settings.getOpenstackImageCacheTTL()));
     }
@@ -129,7 +124,7 @@ public class OpenstackClientWrapper {
         previousImageIds.clear();
     }
 
-    private void initCache(int minutesTTL) {
+    private synchronized void initCache(int minutesTTL) {
 
         if (OpenstackClientWrapper.imageCache == null || imageCacheTTL != minutesTTL) {
             LOG.info(format("[initCache] with TTL [{0}] minutes", minutesTTL));

--- a/src/test/java/cd/go/contrib/elasticagents/openstack/utils/OpenstackClientWrapperTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/openstack/utils/OpenstackClientWrapperTest.java
@@ -50,7 +50,9 @@ public class OpenstackClientWrapperTest {
 
         doReturn(images).when(imageService).list();
 
-        final OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(client);
+        Cache<String, String> imageCache = new Cache2kBuilder<String, String>() {}.entryCapacity(100).build();
+
+        final OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(client, imageCache, null);
 
         // Act
         final String imageId = clientWrapper.getImageId(imageName, transactionId);


### PR DESCRIPTION
There were two constructors of OpenstackClientWrapper, one which
instantiated the cache with 30 min TTL and one with a value from the
plugin settings. This caused the cache to be recreated over and over
again. This was solved by removing the hard coded variety.

A side effect was that many threads were spawned that might or might not
effect performance.

Co-authored-by: "Christian Lövsund <christian.lovsund@jeppesen.com>"