### PR TITLE
Assign work bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'
     compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
-    compile group: 'org.cache2k', name: 'cache2k-api', version: '1.2.0.Final'
+    compile group: 'org.cache2k', name: 'cache2k-api', version: '1.2.2.Final'
     compile group: 'org.cache2k', name: 'cache2k-core', version: '1.2.0.Final'
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.23.4'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.28.2'
     testCompile group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'
     compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
     compile group: 'org.cache2k', name: 'cache2k-api', version: '1.2.2.Final'
-    compile group: 'org.cache2k', name: 'cache2k-core', version: '1.2.0.Final'
+    compile group: 'org.cache2k', name: 'cache2k-core', version: '1.2.2.Final'
 
 
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: project.pluginDesc.goCdVersion
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
     compile group: 'org.pacesys', name: 'openstack4j', version: '2.20'
-    compile group: 'com.google.guava', name: 'guava', version: '27.0.1-jre'
+    compile group: 'com.google.guava', name: 'guava', version: '28.0-jre'
     compile group: 'joda-time', name: 'joda-time', version: '2.10.1'
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
     compile group: 'org.pacesys', name: 'openstack4j', version: '2.20'
     compile group: 'com.google.guava', name: 'guava', version: '28.0-jre'
-    compile group: 'joda-time', name: 'joda-time', version: '2.10.1'
+    compile group: 'joda-time', name: 'joda-time', version: '2.10.2'
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'
     compile group: 'commons-codec', name: 'commons-codec', version: '1.11'

--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    id 'se.patrikerdes.use-latest-versions' version '0.2.7'
-    id 'com.github.ben-manes.versions' version '0.20.0'
-}
-
 apply plugin: 'java'
 apply plugin: 'maven'
 

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackInstances.java
@@ -77,6 +77,8 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
 
     @Override
     public void refreshAll(PluginRequest pluginRequest) throws Exception {
+        final long startTimeMillis = System.currentTimeMillis();
+        LOG.info(format("[refreshAll] refreshed=[{0}]", refreshed));
         if (!refreshed) {
             PluginSettings pluginSettings = pluginRequest.getPluginSettings();
             if (pluginSettings == null) {
@@ -99,6 +101,8 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
             }
             refreshed = true;
         }
+        final long durationInMillis = System.currentTimeMillis() - startTimeMillis;
+        LOG.info(format("[refreshAll] refreshing instances took {0} millis", durationInMillis));
     }
 
     @Override
@@ -198,7 +202,6 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
 
     private OpenStackInstances unregisteredAfterTimeout(PluginSettings settings, Agents knownAgents) throws Exception {
 
-        String agentID;
         Map<String, String> op_instance_prefix = new HashMap<>();
         op_instance_prefix.put("name", settings.getOpenstackVmPrefix());
 
@@ -211,7 +214,7 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
             if (knownAgents.containsAgentWithId(server.getId())) {
                 continue;
             }
-            if(!doesInstanceExist(settings, server.getId()))
+            if (!doesInstanceExist(settings, server.getId()))
                 continue;
             if (DateUtils.addMinutes(server.getCreated(), period.getMinutes()).before(new Date())) {
                 unregisteredInstances.register(new OpenStackInstance(server.getId(),
@@ -225,7 +228,7 @@ public class OpenStackInstances implements AgentInstances<OpenStackInstance> {
 
     @Override
     public Agents instancesCreatedAfterTTL(PluginSettings settings, Agents agents) {
-        ArrayList<Agent> oldAgents = new ArrayList<>();
+        List<Agent> oldAgents = new ArrayList<>();
         for (Agent agent : agents.agents()) {
 
             OpenStackInstance instance = instances.get(agent.elasticAgentId());

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackPlugin.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/OpenStackPlugin.java
@@ -28,6 +28,7 @@ import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 
 import static cd.go.contrib.elasticagents.openstack.Constants.PLUGIN_IDENTIFIER;
+import static java.text.MessageFormat.format;
 
 @Extension
 public class OpenStackPlugin implements GoPlugin {
@@ -53,10 +54,11 @@ public class OpenStackPlugin implements GoPlugin {
                 case REQUEST_CAPABILITIES:
                     return new GetCapabilitiesExecutor().execute();
                 case REQUEST_SHOULD_ASSIGN_WORK:
-                    refreshInstances();
+                    LOG.info(format("[{0}] {1}", request.requestName(), request));
                     return ShouldAssignWorkRequest.fromJSON(request.requestBody()).executor(agentInstances, pluginRequest).execute();
                 case REQUEST_CREATE_AGENT:
                     refreshInstances();
+                    pendingAgents.refreshAll(pluginRequest);
                     return CreateAgentRequest.fromJSON(request.requestBody()).executor(pendingAgents, agentInstances, pluginRequest).execute();
                 case REQUEST_SERVER_PING:
                     refreshInstances();
@@ -89,7 +91,6 @@ public class OpenStackPlugin implements GoPlugin {
     private void refreshInstances() {
         try {
             agentInstances.refreshAll(pluginRequest);
-            pendingAgents.refreshAll(pluginRequest);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/PendingAgent.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/PendingAgent.java
@@ -2,12 +2,13 @@ package cd.go.contrib.elasticagents.openstack;
 
 import cd.go.contrib.elasticagents.openstack.model.JobIdentifier;
 import cd.go.contrib.elasticagents.openstack.requests.CreateAgentRequest;
+import com.thoughtworks.go.plugin.api.logging.Logger;
 
-import static cd.go.contrib.elasticagents.openstack.OpenStackPlugin.LOG;
 import static java.text.MessageFormat.format;
 import static org.apache.commons.lang3.StringUtils.stripToEmpty;
 
 public class PendingAgent {
+    private static final Logger LOG = Logger.getLoggerFor(PendingAgent.class);
     private final String pendingInstanceImageId;
     private final String pendingInstanceFlavorId;
     private OpenStackInstance pendingInstance;

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/ServerPingRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/ServerPingRequestExecutor.java
@@ -17,15 +17,15 @@
 package cd.go.contrib.elasticagents.openstack.executors;
 
 import cd.go.contrib.elasticagents.openstack.*;
+import com.thoughtworks.go.plugin.api.logging.Logger;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 
 import java.util.Collection;
 
-import static cd.go.contrib.elasticagents.openstack.OpenStackPlugin.LOG;
-
 public class ServerPingRequestExecutor implements RequestExecutor {
 
+    private static final Logger LOG = Logger.getLoggerFor(ServerPingRequestExecutor.class);
     private final AgentInstances agentInstances;
     private final PluginRequest pluginRequest;
 
@@ -37,7 +37,7 @@ public class ServerPingRequestExecutor implements RequestExecutor {
     @Override
     public GoPluginApiResponse execute() throws Exception {
         PluginSettings pluginSettings = pluginRequest.getPluginSettings();
-        if(pluginSettings == null) {
+        if (pluginSettings == null) {
             LOG.warn("Openstack elastic agents plugin settings are empty");
             return DefaultGoPluginApiResponse.success("");
         }
@@ -46,11 +46,11 @@ public class ServerPingRequestExecutor implements RequestExecutor {
         Agents missingAgents = new Agents();
 
         for (Agent agent : agents.agents()) {
-            if (agentInstances.find(agent.elasticAgentId()) == null){
+            if (agentInstances.find(agent.elasticAgentId()) == null) {
                 missingAgents.add(agent);
-            }else{
-                if (agent.agentState() == Agent.AgentState.LostContact){
-                    if (!agentInstances.doesInstanceExist(pluginSettings,agent.elasticAgentId())){
+            } else {
+                if (agent.agentState() == Agent.AgentState.LostContact) {
+                    if (!agentInstances.doesInstanceExist(pluginSettings, agent.elasticAgentId())) {
                         missingAgents.add(agent);
                     }
                 }
@@ -58,7 +58,7 @@ public class ServerPingRequestExecutor implements RequestExecutor {
         }
         disableIdleAgents(missingAgents);
 
-        Agents idleAgents = agentInstances.instancesCreatedAfterTTL(pluginSettings,agents);
+        Agents idleAgents = agentInstances.instancesCreatedAfterTTL(pluginSettings, agents);
         disableIdleAgents(idleAgents);
         terminateDisabledAgents(idleAgents, pluginSettings);
 
@@ -75,7 +75,7 @@ public class ServerPingRequestExecutor implements RequestExecutor {
         this.pluginRequest.disableAgents(agents.findInstancesToDisable());
     }
 
-    private void deleteDisabledAgents(Agents agents) throws ServerRequestFailedException{
+    private void deleteDisabledAgents(Agents agents) throws ServerRequestFailedException {
         this.pluginRequest.deleteAgents(agents.findInstancesToTerminate());
     }
 

--- a/src/main/java/cd/go/contrib/elasticagents/openstack/executors/ShouldAssignWorkRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/openstack/executors/ShouldAssignWorkRequestExecutor.java
@@ -16,18 +16,22 @@
 
 package cd.go.contrib.elasticagents.openstack.executors;
 
-import cd.go.contrib.elasticagents.openstack.*;
+import cd.go.contrib.elasticagents.openstack.AgentInstances;
+import cd.go.contrib.elasticagents.openstack.OpenStackInstance;
+import cd.go.contrib.elasticagents.openstack.PluginRequest;
+import cd.go.contrib.elasticagents.openstack.RequestExecutor;
 import cd.go.contrib.elasticagents.openstack.requests.ShouldAssignWorkRequest;
 import cd.go.contrib.elasticagents.openstack.utils.OpenstackClientWrapper;
+import com.thoughtworks.go.plugin.api.logging.Logger;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 
 import java.util.UUID;
 
-import static cd.go.contrib.elasticagents.openstack.OpenStackPlugin.LOG;
 import static java.text.MessageFormat.format;
 
 public class ShouldAssignWorkRequestExecutor implements RequestExecutor {
+    private static final Logger LOG = Logger.getLoggerFor(ShouldAssignWorkRequestExecutor.class);
     private final AgentInstances agentInstances;
     private final PluginRequest pluginRequest;
     private final ShouldAssignWorkRequest request;
@@ -50,7 +54,7 @@ public class ShouldAssignWorkRequestExecutor implements RequestExecutor {
         }
 
         OpenstackClientWrapper clientWrapper = new OpenstackClientWrapper(pluginRequest.getPluginSettings());
-        if ((agentInstances.matchInstance(request.agent().elasticAgentId(), request.properties(), request.environment(), pluginRequest.getPluginSettings(), clientWrapper, transactionId, pluginRequest.getPluginSettings().getUsePreviousOpenstackImage())) ) {
+        if ((agentInstances.matchInstance(request.agent().elasticAgentId(), request.properties(), request.environment(), pluginRequest.getPluginSettings(), clientWrapper, transactionId, pluginRequest.getPluginSettings().getUsePreviousOpenstackImage()))) {
             LOG.info(format("[{0}] [should-assign-work] Work can be assigned to Agent {1}", transactionId, request.agent().elasticAgentId()));
             return DefaultGoPluginApiResponse.success("true");
         } else {


### PR DESCRIPTION
Fixes #45 

This change is trying to fix the bug that stopped work to be assigned when having pending agents.
Looking at the log I found that the API calls to OpenStack were very expensive and the more pending agents we had the longer it took in a linear fashion. Also, I could see many threads doing the same calls which seem wasteful.

Have been running in test and prod for a day now with the bug gone and no known side effects.
